### PR TITLE
CC.compile: Frugal compilation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,18 +15,6 @@ cc_flags="
 
 for src in $(find src -name "*.c" -type f); do
 	obj=sh-bin/$(basename $src).o
-
-	# to speed things up, skip compilation if source file is older than current object file
-
-	if [ -f $obj ]; then
-		src_age=$(date -r $src +%s)
-		obj_age=$(date -r $obj +%s)
-
-		if [ $src_age -lt $obj_age ]; then
-			continue
-		fi
-	fi
-
 	cc $cc_flags -c $src -o $obj &
 done
 

--- a/src/classes/cc.h
+++ b/src/classes/cc.h
@@ -35,7 +35,8 @@ static int cc_internal_add_lib(cc_t* cc, char const* lib) {
 		goto err;
 	}
 
-	char* opts = exec_args_read_out(exec_args);
+	char* const orig_opts = exec_args_read_out(exec_args);
+	char* opts = orig_opts;
 
 	char* opt;
 
@@ -47,7 +48,7 @@ static int cc_internal_add_lib(cc_t* cc, char const* lib) {
 		cc_internal_add_opt(cc, opt);
 	}
 
-	free(opts);
+	free(orig_opts);
 
 err:
 
@@ -288,7 +289,7 @@ static void cc_compile(WrenVM* vm) {
 
 compile: {}
 
-	LOG_FATAL("Compiling %s", path);
+	LOG_SUCCESS("Compiling %s", path);
 
 	// construct exec args
 

--- a/src/classes/cc.h
+++ b/src/classes/cc.h
@@ -207,7 +207,18 @@ static void cc_compile(WrenVM* vm) {
 		goto stat_err;
 	}
 
-	// TODO if the source file is newer than the output, compile
+	// if the source file is newer than the output, compile
+
+	size_t out_mtime = sb.st_mtime;
+
+	if (stat(path, &sb) < 0) {
+		LOG_ERROR("CC.compile: start(\"%s\"): %s", path, strerror(errno))
+	}
+
+	if (sb.st_mtime > out_mtime) {
+		goto compile;
+	}
+
 	// TODO first get source file dependencies
 	// TODO break here if object is more recent than source
 	//      what happens if options change in the meantime though?

--- a/src/util.h
+++ b/src/util.h
@@ -161,7 +161,7 @@ static char* exec_args_read_out(exec_args_t* self) {
 		total += bytes;
 
 		out = realloc(out, total + 1);
-		out[total] = 0;
+		out[total] = '\0';
 
 		memcpy(out + total - bytes, chunk, bytes);
 	}
@@ -169,6 +169,8 @@ static char* exec_args_read_out(exec_args_t* self) {
 	if (bytes < 0) {
 		LOG_WARN("exec_args_read_out: Failed to read from %d: %s", self->pipe_out, strerror(errno))
 	}
+
+	out[total] = '\0';
 
 	return out;
 }


### PR DESCRIPTION
Compiling is expensive, if we can avoid, then cool :)

Only compile if:

- [x] Output file doesn't yet exist.
- [x] The source file is more recent than the equivalent output.
- [x] One of the dependencies (i.e. included headers) of the source file is more recent than the output.
- [x] The compiler options have changed.
- [x] Make `CC.compile` generally a little cleaner.