### PR TITLE
RustC: Compile statically

### DIFF
--- a/skeletons/aqua/build.wren
+++ b/skeletons/aqua/build.wren
@@ -17,7 +17,7 @@ src
 // link program
 
 var linker = Linker.new()
-linker.link(src.toList, ["std-7c7f3bd22bdaa9dd"], "main", true)
+linker.link(src.toList, [], "main", true)
 
 // running
 

--- a/skeletons/rust/build.wren
+++ b/skeletons/rust/build.wren
@@ -7,9 +7,10 @@ src
 	.each { |path| rustc.compile(path) }
 
 // link program
+// XXX linking with pthread is necessary for rust
 
 var linker = Linker.new()
-linker.link(src.toList, ["std-7c7f3bd22bdaa9dd", "pthread"], "cmd")
+linker.link(src.toList, ["pthread"], "cmd")
 
 // running
 

--- a/src/classes/linker.c
+++ b/src/classes/linker.c
@@ -188,8 +188,10 @@ void linker_link(WrenVM* vm) {
 	}
 
 	// construct exec args
+	// we pass '-u__native_entry' to the linker so that it preserves what's necessary for the '__native_entry' symbol
+	// this is only necessary for AQUA, but there's no harm leaving it
 
-	exec_args_t* const exec_args = exec_args_new(2, linker->path, "-L/usr/local/lib");
+	exec_args_t* const exec_args = exec_args_new(3, linker->path, "-L/usr/local/lib", "-Wl,--gc-sections,-u__native_entry");
 	exec_args_add_opts(exec_args, &linker->opts);
 	exec_args_fmt(exec_args, "-L%s", bin_path);
 

--- a/src/classes/rustc.c
+++ b/src/classes/rustc.c
@@ -58,7 +58,7 @@ static int compile_post_hook(task_t* task, void* _data) {
 	compile_post_hook_data_t* const data = _data;
 
 	char* CLEANUP_STR src = NULL;
-	if (asprintf(&src, "%s/target/debug/lib_%lx.so", data->cargo_dir_path, data->hash)) {}
+	if (asprintf(&src, "%s/target/release/lib_%lx.a", data->cargo_dir_path, data->hash)) {}
 
 	char* CLEANUP_STR dest = NULL;
 	if (asprintf(&dest, "%s/%lx.o", bin_path, data->hash)) {}
@@ -279,7 +279,7 @@ compile: {}
 	fprintf(fp, "version = '0.0.0'\n");
 
 	fprintf(fp, "[lib]\n");
-	fprintf(fp, "crate-type = ['dylib']\n");
+	fprintf(fp, "crate-type = ['staticlib']\n");
 	fprintf(fp, "name = '_%lx'\n", hash);
 	fprintf(fp, "path = '%s'\n", path);
 
@@ -300,7 +300,7 @@ compile: {}
 
 	// construct exec args
 
-	exec_args_t* const exec_args = exec_args_new(4, rustc->path, "build", "--manifest-path", cargo_path);
+	exec_args_t* const exec_args = exec_args_new(5, rustc->path, "build", "--release", "--manifest-path", cargo_path);
 	exec_args_save_out(exec_args, PIPE_STDERR); // both warning & errors go through stderr
 
 	// if we've got colour support, force it in the compiler


### PR DESCRIPTION
Resolves #25 

In the end, statically compiling is probably a much better idea, as when packaged into a ZPK that's what you want anyway.