### PR TITLE
Linker.archive

### DIFF
--- a/import/bob.fl
+++ b/import/bob.fl
@@ -13,6 +13,7 @@ class Cc(flags: vec<str>) {
 
 class Linker(flags: vec<str>) {
 	proto link(obj: vec<str>) -> str
+	proto archive(obj: vec<str>) -> str
 }
 
 let install: map<str, str>

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -177,7 +177,7 @@ static int prep_link(state_t* state, flamingo_arg_list_t* args, flamingo_val_t**
 	}
 
 	char* cookie = NULL;
-	asprintf(&cookie, "%s/bob/linker.%s.cookie.%" PRIx64 ".exe", out_path, infinitive, total_hash);
+	asprintf(&cookie, "%s/bob/linker.%s.cookie.%" PRIx64 ".%s", out_path, infinitive, total_hash, archive ? "a" : "l");
 	assert(cookie != NULL);
 	*rv = flamingo_val_make_cstr(cookie);
 


### PR DESCRIPTION
Will be in v0.2.2.

One issue I'm currently facing is when the linker depends on itself (which to be fair isn't directly this PR's responsibility - this should probably be merged before I get around to fixing this).

Here is an example:

```js
let dyn_lib = Linker(["-shared"]).link(lib_obj)
let cmd = Linker(["-liar"]).link(cmd_obj)

install = {
	cmd: "bin/iar",
	dyn_lib: "lib/libiar.so",
}

```

In this example, the command linker relies on `-liar` already being in the LD path, which it obviously isn't because it hasn't been installed anywhere yet.

Solutions I've thought of:

- Incrementally installing. Since we already have the install map before any build steps are taken, we could *try* to install any files after each build step if they've already been generated. I like this solution because it's very generic and won't be constrained just to `Linker`, and allows for funky build setups to work.

Actually, this is the only solution I've thought of so far lol. But I do legit like this solution.