### PR TITLE
fsutil: Don't use `-p` when copying

### DIFF
--- a/src/fsutil.c
+++ b/src/fsutil.c
@@ -10,7 +10,6 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -63,7 +62,7 @@ int copy(char const* src, char const* dst, char** err) {
 	// Finally, actually run the copy command.
 
 	cmd_t cmd;
-	cmd_create(&cmd, "cp", "-RpP", src, dst, NULL);
+	cmd_create(&cmd, "cp", "-RP", src, dst, NULL);
 
 	int const rv = cmd_exec(&cmd);
 

--- a/src/fsutil.h
+++ b/src/fsutil.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdlib.h>
+#include <stdbool.h>
 #include <sys/types.h>
 
 int rm(char const* path, char** err);


### PR DESCRIPTION
Resolves #52 

I don't want to actually use `install(1)` because it can't copy directories recursively. So doing the next best thing.