### PR TITLE
Fix what's chown'd

### DIFF
--- a/src/bsys/bob/main.c
+++ b/src/bsys/bob/main.c
@@ -16,7 +16,6 @@
 #include <flamingo/flamingo.h>
 
 #include <assert.h>
-#include <errno.h>
 #include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/fsutil.c
+++ b/src/fsutil.c
@@ -98,9 +98,13 @@ int set_owner(char const* path) {
 int mkdir_wrapped(char const* path, mode_t mode) {
 	int const rv = mkdir(path, mode);
 
-	if (rv == 0 || errno == EEXIST) {
+	if (rv < 0 && errno == EEXIST) {
+		return 0;
+	}
+
+	if (rv == 0) {
 		set_owner(path);
-		return rv;
+		return 0;
 	}
 
 	return rv;

--- a/src/fsutil.c
+++ b/src/fsutil.c
@@ -89,9 +89,18 @@ int set_owner(char const* path) {
 		return 0;
 	}
 
+	// If the absolute output path hasn't yet been set, this is being called as a means to ensure the output path exists.
+	// That being the case, we can skip to the chown call.
+
+	char* CLEANUP_STR full_path = NULL;
+
+	if (abs_out_path == NULL) {
+		goto chown;
+	}
+
 	// We only want to mess with the permissions of stuff in the output directory (.bob).
 
-	char* const CLEANUP_STR full_path = realpath(path, NULL);
+	full_path = realpath(path, NULL);
 
 	if (full_path == NULL) {
 		assert(errno != ENOMEM);
@@ -104,6 +113,8 @@ int set_owner(char const* path) {
 	}
 
 	// If those checks all pass, we can finally set the owner of the file.
+
+chown:
 
 	if (chown(path, owner, -1) < 0) {
 		LOG_WARN("chown(\"%s\"): %s", path, strerror(errno));

--- a/src/fsutil.c
+++ b/src/fsutil.c
@@ -108,7 +108,7 @@ int set_owner(char const* path) {
 		return -1;
 	}
 
-	if (strstr(full_path, abs_out_path) != abs_out_path) {
+	if (strstr(full_path, abs_out_path) != full_path) {
 		return 0;
 	}
 


### PR DESCRIPTION
Resolve #68 

Concretely, this:

- [x] Fixes the implementation of `mkdir_wrapped`.
- [x] Prevents files who are NOT descendents of `out_path` from being chown'd.
- [x] I guess implicitly the current CI setup tests for this, but I should have a little more comprehensive of a regression test in #67.

Luckily ASAN exists for issues like what 03847fab3910271cd61aa6c2865affb0e258f9cb fixes!