### PR TITLE
`bob sh`

### DIFF
--- a/src/bsys.h
+++ b/src/bsys.h
@@ -42,4 +42,5 @@ static bsys_t const* const BSYS[] = {
 bsys_t const* bsys_identify(void);
 int bsys_build(bsys_t const* bsys, char const* preinstall_prefix);
 int bsys_run(bsys_t const* bsys, int argc, char* argv[]);
+int bsys_sh(bsys_t const* bsys, int argc, char* argv[]);
 int bsys_install(bsys_t const* bsys);

--- a/src/main.c
+++ b/src/main.c
@@ -234,6 +234,12 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
+	else if (strcmp(instr, "sh") == 0) {
+		if (bsys_sh(bsys, argc, argv) == 0) {
+			rv = EXIT_SUCCESS;
+		}
+	}
+
 	else if (strcmp(instr, "install") == 0) {
 		if (bsys_install(bsys) == 0) {
 			rv = EXIT_SUCCESS;

--- a/src/main.c
+++ b/src/main.c
@@ -50,10 +50,9 @@ void usage(void) {
 
 	fprintf(
 		stderr,
-		"usage: %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] "
-		"build\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] run "
-		"[args ...]\n"
+		"usage: %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] build\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] run [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] sh [args ...]\n"
 		"       %1$s [-j jobs] [-p install_prefix] [-C project_directory] [-o out_directory] " "install\n",
 		progname
 	);


### PR DESCRIPTION
Resolves #73 

Actually we should use `$SHELL` instead of `$0` because `$0` is just `argv[0]`.

Simplification of instruction parsing has been cherrypicked from #67 