### PR TITLE
Sloppy `bob sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ This will use the value stored in the `$SHELL` environment variable to launch a 
 You can also just run any command you want by passing it to `bob sh`, like so:
 
 ```console
-bob sh echo \$PATH
+bob sh echo test
+bob sh sh -c "echo \$PATH"
 ```
 
-This will print out the value of the `$PATH` environment variable, and it should be prepended by the `bin` directory of the temporary installation prefix.
+The second command will print out the value of the `$PATH` environment variable, and it should be prepended by the `bin` directory of the temporary installation prefix.
 
 ### Installing
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can also just run any command you want by passing it to `bob sh`, like so:
 
 ```console
 bob sh echo test
-bob sh sh -c "echo \$PATH"
+bob sh -- sh -c "echo \$PATH"
 ```
 
 The second command will print out the value of the `$PATH` environment variable, and it should be prepended by the `bin` directory of the temporary installation prefix.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ To run a project with Bob, run:
 bob run
 ```
 
+Alternatively, you can enter the temporary installation prefix environment with:
+
+```console
+bob sh
+```
+
+This will use the value stored in the `$SHELL` environment variable to launch a shell inside of that prefix, similar to a Python virtual environment.
+You can also just run any command you want by passing it to `bob sh`, like so:
+
+```console
+bob sh echo \$PATH
+```
+
+This will print out the value of the `$PATH` environment variable, and it should be prepended by the `bin` directory of the temporary installation prefix.
+
 ### Installing
 
 Bob always helps his grandma install [Linux Mint](https://linuxmint.com/) on her computer! 👵

--- a/src/bsys.c
+++ b/src/bsys.c
@@ -174,6 +174,12 @@ int bsys_sh(bsys_t const* bsys, int argc, char* argv[]) {
 
 	else {
 		for (int i = 0; i < argc; i++) {
+			// On BSD/macOS, getopt doesn't consume the '--' argument.
+
+			if (strcmp(argv[i], "--") == 0) {
+				continue;
+			}
+
 			cmd_add(&cmd, argv[i]);
 		}
 	}

--- a/src/bsys.c
+++ b/src/bsys.c
@@ -172,7 +172,7 @@ int bsys_sh(bsys_t const* bsys, int argc, char* argv[]) {
 	}
 
 	else {
-		for (int i = 1; i < argc; i++) {
+		for (int i = 0; i < argc; i++) {
 			cmd_add(&cmd, argv[i]);
 		}
 	}

--- a/src/bsys.c
+++ b/src/bsys.c
@@ -173,15 +173,7 @@ int bsys_sh(bsys_t const* bsys, int argc, char* argv[]) {
 	}
 
 	else {
-		for (int i = 0; i < argc; i++) {
-			// On BSD/macOS, getopt doesn't consume the '--' argument.
-
-			if (strcmp(argv[i], "--") == 0) {
-				continue;
-			}
-
-			cmd_add(&cmd, argv[i]);
-		}
+		cmd_add_argv(&cmd, argc, argv);
 	}
 
 	if (cmd_exec_inplace(&cmd) < 0) {

--- a/src/bsys.c
+++ b/src/bsys.c
@@ -168,6 +168,7 @@ int bsys_sh(bsys_t const* bsys, int argc, char* argv[]) {
 			return -1;
 		}
 
+		LOG_SUCCESS("Entering shell ('%s').", shell);
 		cmd_add(&cmd, shell);
 	}
 

--- a/src/bsys/bob/main.c
+++ b/src/bsys/bob/main.c
@@ -284,9 +284,7 @@ found:;
 	// Then, add the arguments passed to the Bob frontend.
 	// If there is no default runner, just pass the arguments from the frontend onwards.
 
-	for (ssize_t i = 0; i < argc; i++) {
-		cmd_add(&cmd, argv[i]);
-	}
+	cmd_add_argv(&cmd, argc, argv);
 
 	// Make sure there actually is something in the command.
 

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -71,6 +71,18 @@ __attribute__((__format__(__printf__, 2, 3))) void cmd_addf(cmd_t* cmd, char con
 	va_end(va);
 }
 
+void cmd_add_argv(cmd_t* cmd, int argc, char* argv[]) {
+	for (ssize_t i = 0; i < argc; i++) {
+		// On BSD/macOS, getopt doesn't consume the '--' argument.
+
+		if (strcmp(argv[i], "--") == 0) {
+			continue;
+		}
+
+		cmd_add(cmd, argv[i]);
+	}
+}
+
 static bool is_executable(char const* path) {
 	struct stat sb;
 

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -21,6 +21,7 @@ typedef struct {
 void cmd_create(cmd_t* cmd, ...);
 void cmd_add(cmd_t* cmd, char const* arg);
 __attribute__((__format__(__printf__, 2, 3))) void cmd_addf(cmd_t* cmd, char const* fmt, ...);
+void cmd_add_argv(cmd_t* cmd, int argc, char* argv[]);
 int cmd_exec_inplace(cmd_t* cmd);
 pid_t cmd_exec_async(cmd_t* cmd);
 int cmd_exec(cmd_t* cmd);

--- a/tests/sh.sh
+++ b/tests/sh.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+. tests/common.sh
+
+# Test the 'bob sh' command.
+# Also kind of a regression test for the following PR:
+# https://github.com/inobulles/bob/pull/77
+
+if [ "$(bob sh echo test | tail -n1)" != "test" ]; then
+	echo "Failed to run command in shell." >&2
+	exit 1
+fi
+
+if [ "$(bob sh sh -c "echo \$PATH" | tail -n1 | cut -d':' -f1)" != ".bob/prefix/bin" ]; then
+	echo "Temporary installation prefix not in \$PATH." >&2
+	exit 1
+fi
+
+# XXX Can't really test 'bob sh' on it's own "properly" I don't think.
+
+export SHELL=uname
+
+if [ "$(bob sh | tail -n1)" != "$(uname)" ]; then
+	echo "Failed to run command in shell." >&2
+	exit 1
+fi

--- a/tests/sh.sh
+++ b/tests/sh.sh
@@ -11,7 +11,7 @@ if [ "$(bob sh echo test | tail -n1)" != "test" ]; then
 	exit 1
 fi
 
-if [ "$(bob sh sh -c "echo \$PATH" | tail -n1 | cut -d':' -f1)" != ".bob/prefix/bin" ]; then
+if [ "$(bob sh -- sh -c "echo \$PATH" | tail -n1 | cut -d':' -f1)" != ".bob/prefix/bin" ]; then
 	echo "Temporary installation prefix not in \$PATH." >&2
 	exit 1
 fi


### PR DESCRIPTION
Somehow, I was extremely sloppy when adding `bob sh` in #74 

This fixes the following issues:

- [x] Forgot to add to README.
- [x] Ignores the first argument passed for some reason.
- [x] Explicit message when entering shell, so we don't get confused about if the command succeeded or not.
- [x] Tests! Merge #76 for this first though ofc.