### PR TITLE
Better preinstallation and clear up installation prefix confusion

### DIFF
--- a/src/bsys.c
+++ b/src/bsys.c
@@ -101,6 +101,7 @@ int bsys_build(bsys_t const* bsys) {
 	}
 
 	// Building installs to a temporary prefix.
+	// It would be nice to only do this when -p is passed, but unfortunately that's not possible because some build steps can depend on preinstalled artifacts.
 
 	if (install_prefix == NULL) {
 		install_prefix = default_tmp_install_prefix;

--- a/src/bsys.h
+++ b/src/bsys.h
@@ -16,9 +16,9 @@ struct bsys_t {
 	bool (*identify)(void);
 	int (*setup)(void);
 	dep_node_t* (*dep_tree)(size_t path_len, uint64_t* path_hashes, bool* circular);
-	int (*build_deps)(dep_node_t* tree, bool preinstall);
-	int (*build)(char const* preinstall_prefix);
-	int (*install)(char const* prefix);
+	int (*build_deps)(dep_node_t* tree);
+	int (*build)(void);
+	int (*install)(void);
 	int (*run)(int argc, char* argv[]);
 	void (*destroy)(void);
 };
@@ -45,7 +45,7 @@ static bsys_t const* const BSYS[] = {
 
 bsys_t const* bsys_identify(void);
 int bsys_dep_tree(bsys_t const* bsys, int argc, char* argv[]);
-int bsys_build(bsys_t const* bsys, char const* preinstall_prefix, bool build_deps);
+int bsys_build(bsys_t const* bsys);
 int bsys_run(bsys_t const* bsys, int argc, char* argv[]);
 int bsys_sh(bsys_t const* bsys, int argc, char* argv[]);
 int bsys_install(bsys_t const* bsys);

--- a/src/bsys/bob/main.c
+++ b/src/bsys/bob/main.c
@@ -17,7 +17,6 @@
 #include <flamingo/flamingo.h>
 
 #include <assert.h>
-#include <errno.h>
 #include <libgen.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -273,16 +272,12 @@ found:
 	return deps_tree(vec->val, path_len, path_hashes, circular);
 }
 
-static int build(char const* preinstall_prefix) {
-	if (setup_install_map(&flamingo, preinstall_prefix) < 0) {
+static int build(void) {
+	if (setup_install_map(&flamingo) < 0) {
 		return -1;
 	}
 
-	return run_build_steps(preinstall_prefix);
-}
-
-static int install(char const* prefix) {
-	return install_all(prefix);
+	return run_build_steps();
 }
 
 static int run(int argc, char* argv[]) {
@@ -371,7 +366,7 @@ bsys_t const BSYS_BOB = {
 	.dep_tree = dep_tree,
 	.build_deps = deps_build,
 	.build = build,
-	.install = install,
+	.install = install_all,
 	.run = run,
 	.destroy = destroy,
 };

--- a/src/bsys/bob/main.c
+++ b/src/bsys/bob/main.c
@@ -167,7 +167,7 @@ static int setup(void) {
 	}
 
 	char* import_path = NULL;
-	asprintf(&import_path, "%s/share/flamingo/import", install_prefix);
+	asprintf(&import_path, "%s/share/flamingo/import", default_final_install_prefix);
 	assert(import_path != NULL);
 
 	flamingo_add_import_path(&flamingo, import_path);

--- a/src/bsys/cargo/main.c
+++ b/src/bsys/cargo/main.c
@@ -9,7 +9,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/cmake/main.c
+++ b/src/bsys/cmake/main.c
@@ -7,7 +7,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/configure/main.c
+++ b/src/bsys/configure/main.c
@@ -7,7 +7,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/gmake/main.c
+++ b/src/bsys/gmake/main.c
@@ -9,7 +9,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/go/main.c
+++ b/src/bsys/go/main.c
@@ -9,7 +9,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/make_freebsd_port/main.c
+++ b/src/bsys/make_freebsd_port/main.c
@@ -9,7 +9,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/bsys/meson/main.c
+++ b/src/bsys/meson/main.c
@@ -7,7 +7,7 @@ static bool identify(void) {
 	return false;
 }
 
-static int build(char const* preinstall_prefix) {
+static int build(void) {
 	return 0;
 }
 

--- a/src/build_step.c
+++ b/src/build_step.c
@@ -70,11 +70,11 @@ void free_build_steps(void) {
 	build_steps = NULL;
 }
 
-int run_build_steps(char const* preinstall_prefix) {
+int run_build_steps(void) {
 	for (size_t i = 0; i < build_step_count; i++) {
 		build_step_t* const step = &build_steps[i];
 
-		if (step->cb(step->data_count, step->data, preinstall_prefix) < 0) {
+		if (step->cb(step->data_count, step->data) < 0) {
 			return -1;
 		}
 	}

--- a/src/build_step.h
+++ b/src/build_step.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef int (*build_step_cb_t)(size_t data_count, void** data, char const* preinstall_prefix);
+typedef int (*build_step_cb_t)(size_t data_count, void** data);
 
 typedef struct {
 	uint64_t unique;
@@ -20,4 +20,4 @@ typedef struct {
 int add_build_step(uint64_t unique, char const* name, build_step_cb_t cb, void* data);
 void free_build_steps(void);
 
-int run_build_steps(char const* preinstall_prefix);
+int run_build_steps(void);

--- a/src/class/cc.c
+++ b/src/class/cc.c
@@ -54,7 +54,7 @@ static void add_flags(cmd_t* cmd, compile_task_t* task) {
 static void add_common(cmd_t* cmd) {
 	// XXX For some reason, at least with clang, -B doesn't work.
 
-	cmd_addf(cmd, "-isystem=%s/include", install_prefix);
+	cmd_addf(cmd, "-isystem%s/include", install_prefix);
 }
 
 static void get_include_deps(compile_task_t* task, char* cc) {

--- a/src/class/cc.c
+++ b/src/class/cc.c
@@ -68,7 +68,7 @@ static void get_include_deps(compile_task_t* task, char* cc) {
 	// TODO Can we do this in parallel easily with 'cmd_exec_async'?
 
 	cmd_t CMD_CLEANUP cmd = {0};
-	cmd_create(&cmd, cc, "-fdiagnostics-color=always", "-MM", "-MT", "", task->src, NULL);
+	cmd_create(&cmd, cc, "-MM", "-MT", "", task->src, NULL);
 	add_flags(&cmd, task);
 	add_common(&cmd, task->preinstall_prefix);
 

--- a/src/class/cc.c
+++ b/src/class/cc.c
@@ -52,7 +52,9 @@ static void add_flags(cmd_t* cmd, compile_task_t* task) {
 }
 
 static void add_common(cmd_t* cmd) {
-	cmd_addf(cmd, "-B%s", install_prefix);
+	// XXX For some reason, at least with clang, -B doesn't work.
+
+	cmd_addf(cmd, "-isystem=%s/include", install_prefix);
 }
 
 static void get_include_deps(compile_task_t* task, char* cc) {

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -40,7 +40,7 @@ typedef struct {
 	flamingo_val_t* out_str;
 } build_step_state_t;
 
-static int link_step(size_t data_count, void** data, char const* preinstall_prefix) {
+static int link_step(size_t data_count, void** data) {
 	assert(data_count == 1); // See comment just before 'add_build_step' in 'prep_link'.
 
 	build_step_state_t* const bss = *data;
@@ -104,10 +104,7 @@ link:;
 		char* cc = getenv("CC");
 		cc = cc == NULL ? "cc" : cc;
 		cmd_create(&cmd, cc, "-fdiagnostics-color=always", "-o", out, NULL);
-
-		if (preinstall_prefix != NULL) {
-			cmd_addf(&cmd, "-B%s", preinstall_prefix);
-		}
+		cmd_addf(&cmd, "-B%s", install_prefix);
 
 #if defined(__APPLE__)
 		cmd_add(&cmd, "-rpath");

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -104,7 +104,7 @@ link:;
 		char* cc = getenv("CC");
 		cc = cc == NULL ? "cc" : cc;
 		cmd_create(&cmd, cc, "-fdiagnostics-color=always", "-o", out, NULL);
-		cmd_addf(&cmd, "-B%s", install_prefix);
+		cmd_addf(&cmd, "-L%s/lib", install_prefix);
 
 #if defined(__APPLE__)
 		cmd_add(&cmd, "-rpath");

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -106,7 +106,7 @@ link:;
 		cmd_create(&cmd, cc, "-fdiagnostics-color=always", "-o", out, NULL);
 
 		if (preinstall_prefix != NULL) {
-			cmd_addf(&cmd, "-L%s/lib", preinstall_prefix);
+			cmd_addf(&cmd, "-B%s", preinstall_prefix);
 		}
 
 #if defined(__APPLE__)

--- a/src/common.h
+++ b/src/common.h
@@ -17,6 +17,7 @@
 #define COMMON_INCLUDED
 
 extern _Bool debugging;
+extern char const* instr;
 extern char const* init_name;
 extern char const* bootstrap_import_path;
 

--- a/src/common.h
+++ b/src/common.h
@@ -27,6 +27,7 @@ extern char const* abs_out_path;
 extern char* deps_path;
 extern _Bool build_deps;
 
+extern _Bool own_prefix;
 extern char const* install_prefix;
 extern char* default_final_install_prefix;
 extern char* default_tmp_install_prefix;

--- a/src/common.h
+++ b/src/common.h
@@ -17,10 +17,15 @@
 #define COMMON_INCLUDED
 
 extern _Bool debugging;
-extern char const* out_path;
-extern char const* abs_out_path;
-extern char const* install_prefix;
-extern char* tmp_install_prefix;
-extern char* deps_path;
 extern char const* init_name;
 extern char const* bootstrap_import_path;
+
+extern char const* out_path;
+extern char const* abs_out_path;
+
+extern char* deps_path;
+extern _Bool build_deps;
+
+extern char const* install_prefix;
+extern char* default_final_install_prefix;
+extern char* default_tmp_install_prefix;

--- a/src/dep_serialization.c
+++ b/src/dep_serialization.c
@@ -163,14 +163,17 @@ int dep_node_deserialize(dep_node_t* root, char* serialized) {
 
 		char const* const tuple = tok + depth - 1;
 		char const* human = tuple;
-		char const* path = strrchr(tuple, ':') + 1;
+		char const* path = strrchr(tuple, ':');
 
-		if (path - 1 == NULL) {
+		if (path == NULL) {
 			path = tuple;
 			human = NULL;
 		}
 
-		if (human != NULL) {
+		else {
+			assert(human != NULL);
+			path++;
+
 			node->human = strdup(human);
 			assert(node->human != NULL);
 			node->human[path - human - 1] = '\0';

--- a/src/dep_tree.c
+++ b/src/dep_tree.c
@@ -222,7 +222,7 @@ downloaded:
 		assert(deps[i].path != NULL);
 
 		deps[i].human = strdup(human);
-		assert(deps[i].path != NULL);
+		assert(deps[i].human != NULL);
 	}
 
 	return 0;
@@ -235,6 +235,7 @@ void deps_node_free(dep_node_t* node) {
 
 	free(node->children);
 	free(node->path);
+	free(node->human);
 }
 
 void deps_tree_free(dep_node_t* tree) {
@@ -435,7 +436,12 @@ build_tree:;
 		}
 
 		node.is_root = false;
+
 		node.path = strdup(dep->path);
+		assert(node.path != NULL);
+
+		node.human = strdup(dep->human);
+		assert(node.human != NULL);
 
 		tree->children = realloc(tree->children, (tree->child_count + 1) * sizeof *tree->children);
 		assert(tree->children != NULL);

--- a/src/dep_tree.c
+++ b/src/dep_tree.c
@@ -392,7 +392,7 @@ build_tree:;
 		// Run the 'dep-tree' command on the dependency and add the resulting dependency trees to ours.
 
 		cmd_t CMD_CLEANUP cmd;
-		cmd_create(&cmd, init_name, "-p", install_prefix, "-C", dep->path, "dep-tree", NULL);
+		cmd_create(&cmd, init_name, "-C", dep->path, "dep-tree", NULL);
 
 		for (size_t j = 0; j < path_len; j++) {
 			cmd_addf(&cmd, "%" PRIx64, path_hashes[j]);

--- a/src/deps.c
+++ b/src/deps.c
@@ -27,16 +27,10 @@ static bool build_task(void* data) {
 	// Actually build the dependency.
 	// We shouldn't pass -o here because the dependency should be built in its own output path.
 	// XXX If the dependency wants to use a different output path, we should probably add a function in the Bob build script to set the output path to something else instead of having an -o switch.
+	// Since we're just building at the moment (no installing), only pass -t, not -p.
 
 	cmd_t CMD_CLEANUP cmd = {0};
-	cmd_create(&cmd, init_name, "-p", install_prefix, "-C", path, NULL);
-
-	if (do_preinstall) {
-		cmd_add(&cmd, "-t");
-		cmd_add(&cmd, tmp_install_prefix);
-	}
-
-	cmd_add(&cmd, "build-no-deps");
+	cmd_create(&cmd, init_name, "-t", tmp_install_prefix, "-C", path, "build-no-deps", NULL);
 
 	int const rv = cmd_exec(&cmd);
 

--- a/src/deps.c
+++ b/src/deps.c
@@ -12,7 +12,6 @@
 #include <assert.h>
 #include <sys/param.h>
 
-static bool do_preinstall = false;
 static pthread_mutex_t logging_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static bool build_task(void* data) {
@@ -30,7 +29,7 @@ static bool build_task(void* data) {
 	// Since we're just building at the moment (no installing), only pass -t, not -p.
 
 	cmd_t CMD_CLEANUP cmd = {0};
-	cmd_create(&cmd, init_name, "-t", tmp_install_prefix, "-C", path, "build-no-deps", NULL);
+	cmd_create(&cmd, init_name, "-D", "-p", install_prefix, "-C", path, "install", NULL);
 
 	int const rv = cmd_exec(&cmd);
 
@@ -100,9 +99,7 @@ is_root:;
 	return false;
 }
 
-int deps_build(dep_node_t* tree, bool preinstall) {
-	do_preinstall = preinstall;
-
+int deps_build(dep_node_t* tree) {
 	// Walk through dependency tree and build each dependency, starting from the leaves.
 	// To do this most efficiently, we start by popping off all the leaves and building them in parallel.
 	// Once that's done, we pop off the next set of leaves, and so on, until we reach the root node (which this current Bob process is meant to build).

--- a/src/deps.c
+++ b/src/deps.c
@@ -5,6 +5,7 @@
 
 #include <cmd.h>
 #include <deps.h>
+#include <fsutil.h>
 #include <logging.h>
 #include <ncpu.h>
 #include <pool.h>
@@ -31,8 +32,16 @@ static bool build_task(void* data) {
 	// Since we're just building at the moment (no installing), only pass -t, not -p.
 
 	cmd_t CMD_CLEANUP cmd = {0};
-	cmd_create(&cmd, init_name, "-D", "-p", install_prefix, "-C", dep->path, "install", NULL);
+	cmd_create(&cmd, init_name, "-D", "-p", install_prefix, "-C", dep->path, NULL);
 
+	bool dep_own_prefix;
+	assert(would_set_owner(install_prefix, &dep_own_prefix) == 0);
+
+	if (dep_own_prefix) {
+		cmd_add(&cmd, "-O");
+	}
+
+	cmd_add(&cmd, "install");
 	int const rv = cmd_exec(&cmd);
 
 	pthread_mutex_lock(&logging_lock);

--- a/src/deps.h
+++ b/src/deps.h
@@ -27,7 +27,7 @@ struct dep_node_t {
 	bool built_deps;
 };
 
-int deps_build(dep_node_t* tree, bool preinstall);
+int deps_build(dep_node_t* tree);
 
 // Dependency tree stuff.
 

--- a/src/deps.h
+++ b/src/deps.h
@@ -17,6 +17,7 @@ typedef struct dep_node_t dep_node_t;
 struct dep_node_t {
 	bool is_root; // The root dependency node is self.
 	char* path;
+	char* human; // Can be NULL.
 
 	size_t child_count;
 	struct dep_node_t* children;

--- a/src/fsutil.h
+++ b/src/fsutil.h
@@ -8,6 +8,7 @@
 
 int rm(char const* path, char** err);
 int copy(char const* src, char const* dst, char** err);
+int would_set_owner(char const* path, bool* would);
 int set_owner(char const* path);
 int mkdir_wrapped(char const* path, mode_t mode);
 int mkdir_recursive(char const* path, mode_t mode);

--- a/src/install.c
+++ b/src/install.c
@@ -31,7 +31,10 @@ int setup_install_map(flamingo_t* flamingo) {
 		}
 
 		if (map->val->kind == FLAMINGO_VAL_KIND_NONE) {
-			LOG_WARN("Install map not set; nothing to install!"); // TODO Don't warn when just building please.
+			if (strcmp(instr, "build") != 0) {
+				LOG_WARN("Install map not set; nothing to install!");
+			}
+
 			return 0;
 		}
 

--- a/src/install.c
+++ b/src/install.c
@@ -168,6 +168,8 @@ static int install_single(flamingo_val_t* key_val, char* val, bool installing_co
 		return -1;
 	}
 
+	set_owner(install_path);
+
 #if defined(__APPLE__)
 	free(err);
 	err = NULL;

--- a/src/install.c
+++ b/src/install.c
@@ -83,7 +83,7 @@ static int install_single(flamingo_val_t* key_val, char* val, bool installing_co
 	char* const STR_CLEANUP path = realerpath(key);
 
 	if (path == NULL) {
-		LOG_FATAL("Couldn't find source file (from install map): %s", key_val->str.str);
+		LOG_FATAL("Couldn't find source file (from install map): %s", key);
 		return -1;
 	}
 

--- a/src/install.h
+++ b/src/install.h
@@ -5,7 +5,7 @@
 
 #include <flamingo/flamingo.h>
 
-int setup_install_map(flamingo_t* flamingo, char const* prefix);
-int install_all(char const* prefix);
+int setup_install_map(flamingo_t* flamingo);
+int install_all(void);
 char* cookie_to_output(char* cookie, flamingo_val_t** key_val_ref);
 int install_cookie(char* cookie);

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 
 // Global options go here so they're accessible by everyone.
 
+char const* instr = NULL;
 bool debugging = false;
 char const* init_name = "bob";
 char const* bootstrap_import_path = "import";
@@ -292,7 +293,7 @@ int main(int argc, char* argv[]) {
 		usage();
 	}
 
-	char const* const instr = *argv++;
+	instr = *argv++;
 
 	if (strcmp(instr, "build") == 0) {
 		if (bsys_build(bsys) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -143,6 +143,22 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
+	// Get install prefix and ensure it exists.
+	// We must do this before chdir'ing - don't think I need to explain.
+
+	if (install_prefix == NULL) {
+		install_prefix = getenv("PREFIX");
+	}
+
+	if (install_prefix != NULL) {
+		install_prefix = realerpath(install_prefix);
+
+		if (install_prefix == NULL) {
+			LOG_FATAL("Install prefix path \"%s\" doesn't exist.", install_prefix);
+			return EXIT_FAILURE;
+		}
+	}
+
 	// If project path wasn't set, set it to the current working directory.
 	// Then, make it absolute.
 	// Finally, actually change to that directory.
@@ -155,7 +171,7 @@ int main(int argc, char* argv[]) {
 	project_path = realerpath(rel_project_path);
 
 	if (project_path == NULL) {
-		LOG_FATAL("Invalid project path (\"%s\")", rel_project_path);
+		LOG_FATAL("Project path \"%s\" doesn't exist.", rel_project_path);
 		return EXIT_FAILURE;
 	}
 
@@ -193,12 +209,6 @@ int main(int argc, char* argv[]) {
 	if (abs_out_path == NULL) {
 		LOG_FATAL("realpath(\"%s\"): %s", out_path, strerror(errno));
 		return EXIT_FAILURE;
-	}
-
-	// Get install prefix and ensure it exists.
-
-	if (install_prefix == NULL) {
-		install_prefix = getenv("PREFIX");
 	}
 
 	// Get default final and temporary install prefixes.

--- a/src/main.c
+++ b/src/main.c
@@ -35,6 +35,7 @@ char const* abs_out_path = NULL;
 char* deps_path = NULL;
 bool build_deps = true;
 
+bool own_prefix = false;
 char const* install_prefix = NULL;
 char* default_final_install_prefix = NULL;
 char* default_tmp_install_prefix = NULL;
@@ -58,10 +59,10 @@ void usage(void) {
 
 	fprintf(
 		stderr,
-		"usage: %1$s [-j jobs] [-p install_prefix] [-D] [-C project_directory] [-o out_directory] build\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-C project_directory] [-o out_directory] run [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-C project_directory] [-o out_directory] sh [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-C project_directory] [-o out_directory] " "install\n",
+		"usage: %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] build\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] run [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] sh [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] " "install\n",
 		progname
 	);
 
@@ -77,7 +78,7 @@ int main(int argc, char* argv[]) {
 
 	int c;
 
-	while ((c = getopt(argc, argv, "C:Dj:o:p:")) != -1) {
+	while ((c = getopt(argc, argv, "C:Dj:Oo:p:")) != -1) {
 		switch (c) {
 		case 'C':
 			project_path = optarg;
@@ -90,6 +91,9 @@ int main(int argc, char* argv[]) {
 				exit(EXIT_FAILURE);
 			}
 
+			break;
+		case 'O':
+			own_prefix = true;
 			break;
 		case 'o':
 			out_path = optarg;

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -11,7 +11,10 @@
 # Make sure everything is clean.
 
 INSTALL_PATH=/usr/local/share/bob_chown_test.fl
+DEP_INSTALL_PATH=/usr/local/share/bob_chown_dep_test.fl
+
 SUDO rm -rf tests/chown/.bob $INSTALL_PATH
+SUDO rm -rf tests/chown/dep/.bob $DEP_INSTALL_PATH
 
 # Create a user.
 
@@ -47,10 +50,17 @@ SUDO bob -C tests/chown install
 
 # XXX Annoyingly, 'stat -f %Su' doesn't work on Linux (you have to use 'stat -c %U').
 
-owner=$(ls -ld /usr/local/share/bob_chown_test.fl | awk '{print $3}')
+owner=$(ls -ld $INSTALL_PATH | awk '{print $3}')
 
 if [ $owner != "root" ]; then
-	echo "Installed files are not owned by root." >&2
+	echo "Installed file is not owned by root." >&2
+	exit 1
+fi
+
+dep_owner=$(ls -ld $DEP_INSTALL_PATH | awk '{print $3}')
+
+if [ $dep_owner != "root" ]; then
+	echo "Installed dependency file is not owned by root." >&2
 	exit 1
 fi
 

--- a/tests/chown.sh
+++ b/tests/chown.sh
@@ -53,3 +53,8 @@ if [ $owner != "root" ]; then
 	echo "Installed files are not owned by root." >&2
 	exit 1
 fi
+
+# chown back to the original user, so things aren't annoying.
+
+uid=$(id -u)
+SUDO chown -R $uid tests/chown

--- a/tests/chown/dep/build.fl
+++ b/tests/chown/dep/build.fl
@@ -3,10 +3,6 @@
 
 import bob
 
-deps = [
-	Dep.local("dep"),
-]
-
 install = {
-	"build.fl": "share/bob_chown_test.fl",
+	"build.fl": "share/bob_chown_dep_test.fl",
 }

--- a/tests/dep_tree.sh
+++ b/tests/dep_tree.sh
@@ -29,9 +29,9 @@ fi
 DEP1=$(find $BOB_DEPS_PATH -name "*dep1*")
 DEP2=$(find $BOB_DEPS_PATH -name "*dep2*")
 
-printf "$DEP1\n" > $DEPS_TREE_PATH.expected
-printf "\t$DEP2\n" >> $DEPS_TREE_PATH.expected
-printf "$DEP2\n" >> $DEPS_TREE_PATH.expected
+printf "dep1:$DEP1\n" > $DEPS_TREE_PATH.expected
+printf "\tdep2:$DEP2\n" >> $DEPS_TREE_PATH.expected
+printf "dep2:$DEP2\n" >> $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected." >&2
@@ -53,8 +53,8 @@ fi
 cp tests/deps/build.changed.fl tests/deps/build.fl
 try "Failed to create dependency tree after changing dependencies"
 
-printf "$DEP1\n" > $DEPS_TREE_PATH.expected
-printf "\t$DEP2\n" >> $DEPS_TREE_PATH.expected
+printf "dep1:$DEP1\n" > $DEPS_TREE_PATH.expected
+printf "\tdep2:$DEP2\n" >> $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected after changing dependencies." >&2
@@ -66,7 +66,7 @@ fi
 cp tests/deps/build.duplicate.fl tests/deps/build.fl
 try "Failed to create dependency tree with duplicates in the dependency vector"
 
-printf "$DEP2\n" > $DEPS_TREE_PATH.expected
+printf "dep2:$DEP2\n" > $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected with duplicates in the dependency vector." >&2

--- a/tests/deps.sh
+++ b/tests/deps.sh
@@ -16,25 +16,3 @@ if [ $? != 0 ]; then
 	echo "Failed to run binary pre-installed by dependency: $out" >&2
 	exit 1
 fi
-
-# If we're just building, make sure nothing is pre-installed to the temporary installation prefix for no reason.
-
-cp tests/deps/build.normal.fl tests/deps/build.fl
-rm -rf tests/deps/.bob tests/deps/dep1/.bob tests/deps/dep2/.bob
-
-out=$(bob -C tests/deps build 2>&1)
-
-if [ $? != 0 ]; then
-	echo "Failed to build: $out" >&2
-	exit 1
-fi
-
-if [ -f tests/deps/.bob/prefix/bin/dep2 ]; then
-	echo "Dependency binary has been installed to temporary installation prefix when it shouldn't've." >&2
-	exit 1
-fi
-
-if [ -f tests/deps/dep2/.bob/prefix/bin/dep2 ]; then
-	echo "Dependency binary has been installed to own temporary installation prefix when it shouldn't've." >&2
-	exit 1
-fi

--- a/tests/deps/build.normal.fl
+++ b/tests/deps/build.normal.fl
@@ -7,3 +7,5 @@ deps = [
 	Dep.local("dep1"),
 	Dep.local("dep2"),
 ]
+
+Cc([]).compile(["main.c"])

--- a/tests/deps/dep2/build.fl
+++ b/tests/deps/dep2/build.fl
@@ -5,6 +5,7 @@ import bob
 
 install = {
 	Linker([]).link(Cc([]).compile(["main.c"])): "bin/dep2",
+	"dep2.h": "include/dep2.h"
 }
 
 run = ["dep2"]

--- a/tests/deps/dep2/dep2.h
+++ b/tests/deps/dep2/dep2.h
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#pragma once
+
+#define __DEP2__

--- a/tests/deps/main.c
+++ b/tests/deps/main.c
@@ -4,7 +4,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <dep2.h>
+
+#if !defined(__DEP2__)
+# error "dep2.h not included"
+#endif
+
 int main(void) {
-	printf("Hello, world! (dep2)\n");
+	printf("Hello, world! (deps)\n");
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This PR intends to fix a lot of the weirdness and inconsistency w.r.t. preinstallation.

Basically:

- [x] ~Preinstall everything, including non-cookies, and do this before anything else. This is because 1) a dependent could depend on this or 2) the runtime itself could depend on it. In fact, this needs to be extended to installation more generally, or we might get the case where we depend on a preinstalled header, but once we do `bob install`, since we're not necessarily installing the header first, things fail to compile.~ Runtime is only relevant for `run` and `sh`, in which case a full installation to the temporary install prefix is done anyway. If a build step need to depend on an installed file, then it should be preinstalled (i.e. with a cookie). Possibly we could have a `Res.preinstall()` function or something for this, but let's only think of that when the need arises.
- [x] Add include path to compiler flags. -> Done with `-B`.
- [x] ~Dependencies are not installed; figure out if we want to do this or not.~ They are now, and it's going to be complicated/confusing to do this differently.
- [x] Always preinstall for a dependency, even when just doing a `build` (we could be depending on one of its headers e.g.).
- [x] ~Prefix tests.~ This isn't super relevant anymore. I guess everything is for the most part covered by other tests (install, run, sh).
- [x] Check that installed files are being chown'd correctly, even for dependencies (add this to chown test).
- [x] Use this opportunity to use human names for dependencies in logs when building them.

## User scenarios

This should really wind up being documentation at some point -> #82

### Simply building

Currently, unless we explicitly pass the `-t` option, the prefix passed to `bsys_build` is just `NULL`. In that case, after the Bob bsys calls `setup_install_map`, the `install.c` prefix is set to `NULL`, too. This entails that `install_cookie` and `install_all` will both do nothing.

When `-t` is passed, we should really run an install step (`install` function, like when running) to the temporary prefix, as this takes care for everything for us. Then again, maybe it makes more sense to have a different explicit name for this to not overload the `build` command and make things confusing. I'm thinking:

- New `preinstall` command which can take in `-t` but otherwise just infers the temporary prefix, like when we're running.
- Remove the `build-no-deps` command and replace it with a switch which prevents dependencies from being built. This can honestly be documented, there's no real reason to obscure it (the same way I guess there might be a reason to obscure `dep-tree`, though even that should probably also be documented).

The last thing to 

### Running

Currently, we start by calling `install`, which implicitly builds too. This is called with `to_tmp_prefix` set obviously.

### Installing

Ditto, but we don't set `to_tmp_prefix`.

Actually it turns out running and installing are the "easy" cases. Maybe we should just clean up `install.c` to make clear where different prefixes come from.

## Confusing names

I think most of the confusion here stems from nomenclature. In code (and even in this issue), the terms "prefix", "temporary installation prefix", and "preinstallation" are used inconsistently. I propose these new definitions:

- Preinstallation: Purely the act of installing stuff before we've finished building. This is always the case when installing cookies (see `install_cookie`).
- Installation prefix: The generic term for a prefix, temporary or final, to which we install.
- Temporary prefix: By default `.bob/prefix`, but can be set through `-t`. This is the prefix that `run` and `sh` use.
- Final prefix: The default depends on the system, but on FreeBSD this would be `/usr/local`. This is the prefix that `install` uses by default.

I do realize that, for the `install` command, there isn't really a need to have a separate `-t` option. It acts the same whether it's installing to a temporary or final prefix. In fact, since `run` and `sh` should deterministically install to a temporary prefix by default and `install` should deterministically install to a final prefix by default, we can get by with just a `-p` option.

This is quite good because it means, to build a dependency, it suffices to just run `bob -p $parent_tmp_prefix install` (instead of needing a `build-no-deps` or an (erroneously named) `preinstall` command).