### PR TITLE
linker: Static linking dependencies

### DIFF
--- a/src/class/cc.c
+++ b/src/class/cc.c
@@ -152,7 +152,7 @@ static bool compile_task(void* data) {
 	cmd_log(&cmd, task->out, task->src, "compile", "compiled", true);
 	pthread_mutex_unlock(&task->bss->logging_lock);
 
-	if (!stop && install_cookie(task->out) < 0) {
+	if (!stop && install_cookie(task->out, true) < 0) {
 		stop = true;
 	}
 
@@ -275,7 +275,7 @@ static int compile_step(size_t data_count, void** data) {
 			if (vres == VALIDATION_RES_SKIP) {
 				log_already_done(out, src, "compiled");
 
-				if (install_cookie(out) < 0) {
+				if (install_cookie(out, false) < 0) {
 					vres = VALIDATION_RES_ERR;
 				}
 			}

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -69,6 +69,17 @@ static int link_step(size_t data_count, void** data) {
 		goto link;
 	}
 
+	// Re-link if any statically linked dependencies have changed.
+	// We know we have a static dependency when there's a cookie in the flags.
+
+	for (size_t i = 0; i < bss->state->flags->vec.count; i++) {
+		flamingo_val_t* const flag = bss->state->flags->vec.elems[i];
+
+		if (has_built_cookie(flag->str.str, flag->str.size)) {
+			goto link;
+		}
+	}
+
 	// Check modification times.
 
 	bool do_link;

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -95,7 +95,7 @@ static int link_step(size_t data_count, void** data) {
 	// Already linked.
 
 	log_already_done(out, pretty, bss->past);
-	rv = install_cookie(out);
+	rv = install_cookie(out, false);
 
 	goto done;
 
@@ -156,7 +156,7 @@ link:;
 	cmd_free(&cmd);
 
 	if (rv == 0) {
-		rv = install_cookie(out);
+		rv = install_cookie(out, true);
 	}
 
 done:

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -6,6 +6,8 @@
 #include <cookie.h>
 #include <str.h>
 
+#include <flamingo/flamingo.h>
+
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -25,4 +27,28 @@ char* gen_cookie(char* path, size_t path_size, char const* ext) {
 	}
 
 	return cookie;
+}
+
+static pthread_mutex_t built_cookies_mutex = PTHREAD_MUTEX_INITIALIZER;
+size_t built_cookie_count = 0;
+char** built_cookies = NULL; // XXX Shouldn't really worry about freeing all of this, there's no real chance of a leak.
+
+void add_built_cookie(char* cookie) {
+	pthread_mutex_lock(&built_cookies_mutex);
+
+	built_cookies = realloc(built_cookies, ++built_cookie_count * sizeof *built_cookies);
+	assert(built_cookies != NULL);
+	built_cookies[built_cookie_count - 1] = strdup(cookie);
+
+	pthread_mutex_unlock(&built_cookies_mutex);
+}
+
+bool has_built_cookie(char* cookie, size_t len) {
+	for (size_t i = 0; i < built_cookie_count; i++) {
+		if (flamingo_cstrcmp(cookie, built_cookies[i], len) == 0) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#include <common.h>
+
+#include <cookie.h>
+#include <str.h>
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+char* gen_cookie(char* path, size_t path_size, char const* ext) {
+	char* cookie = NULL;
+	asprintf(&cookie, "%s/bob/%.*s.cookie.%" PRIx64 ".%s", out_path, (int) path_size, path, str_hash(path, path_size), ext);
+	assert(cookie != NULL);
+
+	size_t const prefix_len = strlen(out_path) + strlen("/bob/");
+
+	for (size_t i = prefix_len; i < prefix_len + path_size; i++) {
+		if (cookie[i] == '/') {
+			cookie[i] = '_';
+		}
+	}
+
+	return cookie;
+}

--- a/src/cookie.h
+++ b/src/cookie.h
@@ -3,6 +3,14 @@
 
 #pragma once
 
+#include <pthread.h>
+#include <stdbool.h>
 #include <stdlib.h>
 
+extern size_t built_cookie_count;
+extern char** built_cookies;
+
 char* gen_cookie(char* path, size_t path_size, char const* ext);
+
+void add_built_cookie(char* cookie);
+bool has_built_cookie(char* cookie, size_t len);

--- a/src/cookie.h
+++ b/src/cookie.h
@@ -5,7 +5,6 @@
 
 #include <pthread.h>
 #include <stdbool.h>
-#include <stdlib.h>
 
 extern size_t built_cookie_count;
 extern char** built_cookies;

--- a/src/cookie.h
+++ b/src/cookie.h
@@ -3,28 +3,6 @@
 
 #pragma once
 
-#include <common.h>
-
-#include <str.h>
-
-#include <assert.h>
-#include <inttypes.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
-static inline char* gen_cookie(char* path, size_t path_size, char const* ext) {
-	char* cookie = NULL;
-	asprintf(&cookie, "%s/bob/%.*s.cookie.%" PRIx64 ".%s", out_path, (int) path_size, path, str_hash(path, path_size), ext);
-	assert(cookie != NULL);
-
-	size_t const prefix_len = strlen(out_path) + strlen("/bob/");
-
-	for (size_t i = prefix_len; i < prefix_len + path_size; i++) {
-		if (cookie[i] == '/') {
-			cookie[i] = '_';
-		}
-	}
-
-	return cookie;
-}
+char* gen_cookie(char* path, size_t path_size, char const* ext);

--- a/src/install.c
+++ b/src/install.c
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Aymeric Wibo
 
-#include <apple.h>
 #include <common.h>
+
+#include <apple.h>
+#include <cookie.h>
 #include <frugal.h>
 #include <fsutil.h>
 #include <install.h>
@@ -206,7 +208,7 @@ int install_all(void) {
 
 char* cookie_to_output(char* cookie, flamingo_val_t** key_val_ref) {
 	if (install_map == NULL) {
-		return 0;
+		return NULL;
 	}
 
 	for (size_t i = 0; i < install_map->map.count; i++) {
@@ -238,7 +240,13 @@ int install_cookie(char* cookie) {
 	flamingo_val_t* key = NULL;
 	char* const STR_CLEANUP out = cookie_to_output(cookie, &key);
 
-	if (out != NULL && install_single(key, out, true) < 0) {
+	if (out == NULL) {
+		return 0;
+	}
+
+	add_built_cookie(cookie);
+
+	if (install_single(key, out, true) < 0) {
 		return -1;
 	}
 

--- a/src/install.c
+++ b/src/install.c
@@ -236,7 +236,7 @@ char* cookie_to_output(char* cookie, flamingo_val_t** key_val_ref) {
 	return NULL;
 }
 
-int install_cookie(char* cookie) {
+int install_cookie(char* cookie, bool built) {
 	flamingo_val_t* key = NULL;
 	char* const STR_CLEANUP out = cookie_to_output(cookie, &key);
 
@@ -244,7 +244,9 @@ int install_cookie(char* cookie) {
 		return 0;
 	}
 
-	add_built_cookie(cookie);
+	if (built) {
+		add_built_cookie(cookie);
+	}
 
 	if (install_single(key, out, true) < 0) {
 		return -1;

--- a/src/install.h
+++ b/src/install.h
@@ -8,4 +8,4 @@
 int setup_install_map(flamingo_t* flamingo);
 int install_all(void);
 char* cookie_to_output(char* cookie, flamingo_val_t** key_val_ref);
-int install_cookie(char* cookie);
+int install_cookie(char* cookie, bool built);

--- a/tests/static_link.sh
+++ b/tests/static_link.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -e
+
+. tests/common.sh
+
+# Regression test for the following PR:
+# https://github.com/inobulles/bob/pull/85
+
+BOB_PATH=tests/static_link/.bob
+rm -rf $BOB_PATH
+
+LIB1=$BOB_PATH/prefix/lib/lib1.a
+LIB2=$BOB_PATH/prefix/lib/lib2.a
+CMD=$BOB_PATH/prefix/bin/cmd
+
+# Build everything and get initial times.
+
+bob -C tests/static_link build
+lib1_mtime=$(date -r $LIB1 +%s)
+lib2_mtime=$(date -r $LIB2 +%s)
+cmd_mtime=$(date -r $CMD +%s)
+
+# Do nothing.
+# We expect none of the files to be rebuilt.
+
+sleep 1
+bob -C tests/static_link build
+
+[ $lib1_mtime -eq $(date -r $LIB1 +%s) ]
+[ $lib2_mtime -eq $(date -r $LIB2 +%s) ]
+[ $cmd_mtime -eq $(date -r $CMD +%s) ]
+
+# Update lib2.
+# cmd doesn't depend on this, so we only expect lib2 to be rebuilt.
+
+sleep 1
+touch tests/static_link/lib2.c
+bob -C tests/static_link build
+
+new_lib2_mtime=$(date -r $LIB2 +%s)
+
+[ $lib1_mtime -eq $(date -r $LIB1 +%s) ]
+[ $lib2_mtime -lt $new_lib2_mtime ]
+[ $cmd_mtime -eq $(date -r $CMD +%s) ]
+
+lib2_mtime=$new_lib2_mtime
+
+# Update lib1.
+# cmd does depend on this, so we expect cmd to be rebuilt as well.
+
+sleep 1
+touch tests/static_link/lib1.c
+bob -C tests/static_link build
+
+new_lib1_mtime=$(date -r $LIB1 +%s)
+new_cmd_mtime=$(date -r $CMD +%s)
+
+[ $lib1_mtime -lt $new_lib1_mtime ]
+[ $lib2_mtime -eq $(date -r $LIB2 +%s) ]
+[ $cmd_mtime -lt $new_cmd_mtime ]

--- a/tests/static_link/build.fl
+++ b/tests/static_link/build.fl
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Aymeric Wibo
+
+import bob
+
+let lib1 = Linker([]).archive(Cc([]).compile(["lib1.c"]))
+let lib2 = Linker([]).archive(Cc([]).compile(["lib2.c"]))
+
+let cmd = Linker([lib1]).link(Cc([]).compile(["main.c"]))
+
+install = {
+	lib1: "lib/lib1.a",
+	lib2: "lib/lib2.a",
+	cmd: "bin/cmd"
+}

--- a/tests/static_link/lib1.c
+++ b/tests/static_link/lib1.c
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo

--- a/tests/static_link/lib2.c
+++ b/tests/static_link/lib2.c
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo

--- a/tests/static_link/main.c
+++ b/tests/static_link/main.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+	printf("Hello, world!\n");
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Currently, if you do something like:

```js
let archive = Linker([]).archive(lib_obj)
let cmd = Linker([archive]).link(cmd_obj)
```

If `archive` is re-linked, `cmd` will not be re-linked.

Static link dependencies should be detected and, if they change, the dependant should also be relinked.

Todo:

- [x] Actually do this.
- [x] Tests.