### PR TITLE
Aquariums

### DIFF
--- a/import/bob.fl
+++ b/import/bob.fl
@@ -73,6 +73,9 @@ class Aquarium(template: str) {
 	# Add a kernel template to the aquarium.
 	proto add_kernel(kernel: str) -> void
 
+	# Execute an arbitrary command in the aquarium.
+	proto exec(cmd: str) -> void
+
 	# Create a bootable image from the aquarium.
 	# A kernel must have been added to the aquarium with `set_kernel()` before calling this method.
 	proto image -> str

--- a/import/bob.fl
+++ b/import/bob.fl
@@ -64,31 +64,28 @@ class Platform {
 	static proto getenv(key: str) -> str
 }
 
-# This class provides a way to build and interact with aquariums.
+# This class provides a way to create and interact with aquariums.
 # Bob does not come with aquariums by default, so you must have already installed it.
 # It uses the aquarium command line tool to build aquariums, so you don't need to re-link it if you installed aquariums a posteriori.
 #
 # The constructor just creates a new aquarium from a template.
 class Aquarium(template: str) {
-	# Builder aquarium stuff.
-
-	# Create a builder aquarium from a template and a project path.
-	# The builder aquarium will be created from the template and will have Bob installed in it.
-	# Then, the project at the given path will be copied over to the builder aquarium and be built within that aquarium.
-	static proto builder(template: str, project_path: str) -> Aquarium
-
-	# Install the built project to a target aquarium.
-	# The aquarium this is called on must be a builder aquarium, i.e. one created with `Aquarium.builder()`.
-	proto install_to(target: Aquarium) -> void
-
-	# Regular aquarium stuff.
-
 	# Add a kernel template to the aquarium.
 	proto add_kernel(kernel: str) -> void
 
 	# Create a bootable image from the aquarium.
 	# A kernel must have been added to the aquarium with `set_kernel()` before calling this method.
 	proto image -> str
+}
+
+# This class provides a way to build projects inside of aquariums.
+# All the same disclaimers from the `Aquarium` class apply here too.
+#
+# The constructor creates a builder aquarium from the template and will have Bob installed to it.
+# Then, the project at the given path will be copied over to the builder aquarium and be built within that aquarium.
+class AquariumBuilder(template: str, project_path: str) {
+	# Install the built project to a target aquarium.
+	proto install_to(target: Aquarium) -> void
 }
 
 # Vector of other projects this project depends on.

--- a/import/bob.fl
+++ b/import/bob.fl
@@ -64,6 +64,33 @@ class Platform {
 	static proto getenv(key: str) -> str
 }
 
+# This class provides a way to build and interact with aquariums.
+# Bob does not come with aquariums by default, so you must have already installed it.
+# It uses the aquarium command line tool to build aquariums, so you don't need to re-link it if you installed aquariums a posteriori.
+#
+# The constructor just creates a new aquarium from a template.
+class Aquarium(template: str) {
+	# Builder aquarium stuff.
+
+	# Create a builder aquarium from a template and a project path.
+	# The builder aquarium will be created from the template and will have Bob installed in it.
+	# Then, the project at the given path will be copied over to the builder aquarium and be built within that aquarium.
+	static proto builder(template: str, project_path: str) -> Aquarium
+
+	# Install the built project to a target aquarium.
+	# The aquarium this is called on must be a builder aquarium, i.e. one created with `Aquarium.builder()`.
+	proto install_to(target: Aquarium) -> void
+
+	# Regular aquarium stuff.
+
+	# Add a kernel template to the aquarium.
+	proto add_kernel(kernel: str) -> void
+
+	# Create a bootable image from the aquarium.
+	# A kernel must have been added to the aquarium with `set_kernel()` before calling this method.
+	proto image -> str
+}
+
 # Vector of other projects this project depends on.
 let deps: vec<Dep> = []
 

--- a/import/bob.fl
+++ b/import/bob.fl
@@ -87,6 +87,9 @@ class Aquarium(template: str) {
 # The constructor creates a builder aquarium from the template and will have Bob installed to it.
 # Then, the project at the given path will be copied over to the builder aquarium and be built within that aquarium.
 class AquariumBuilder(template: str, project_path: str) {
+	# Add overlay template to the builder aquarium.
+	proto add_overlay(overlay: str) -> void
+
 	# Install the built project to a target aquarium.
 	proto install_to(target: Aquarium) -> void
 }

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -33,7 +33,7 @@ static int add_kernel(state_t* state, flamingo_arg_list_t* args, flamingo_val_t*
 static int prep_image(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 0);
 
-	// TODO
+	// TODO Imaging build step.
 
 	return 0;
 }

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -162,7 +162,7 @@ static int prep_exec(aquarium_state_t* state, flamingo_arg_list_t* args) {
 	bss->state = state;
 	bss->cmd = cmd;
 
-	return add_build_step(MAGIC ^ strhash(__func__) + exec_count++, "Executing command on aquarium", exec_step, bss);
+	return add_build_step((MAGIC ^ strhash(__func__)) + exec_count++, "Executing command on aquarium", exec_step, bss);
 }
 
 static int prep_image(aquarium_state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -126,7 +126,7 @@ static int image_step(size_t data_count, void** data) {
 	return 0;
 }
 
-static int add_kernel(aquarium_state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+static int add_kernel(aquarium_state_t* state, flamingo_arg_list_t* args) {
 	assert(args->count == 1);
 
 	if (args->args[0]->kind != FLAMINGO_VAL_KIND_STR) {
@@ -187,7 +187,7 @@ static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_va
 	aquarium_state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
 
 	if (flamingo_cstrcmp(callable->name, "add_kernel", callable->name_size) == 0) {
-		return add_kernel(state, args, rv);
+		return add_kernel(state, args);
 	}
 
 	else if (flamingo_cstrcmp(callable->name, "exec", callable->name_size) == 0) {

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -13,26 +13,28 @@
 #include <assert.h>
 #include <inttypes.h>
 
+#include "aquarium_common.h"
+
 #define AQUARIUM "Aquarium"
 #define MAGIC (strhash(AQUARIUM "() magic"))
-
-typedef struct {
-	char* template;
-	char* kernel;
-} state_t;
 
 static size_t aquarium_count = 0;
 
 static int create_step(size_t data_count, void** data) {
 	for (size_t i = 0; i < data_count; i++) {
-		state_t* const state = data[i];
+		aquarium_state_t* const state = data[i];
 		size_t id = aquarium_count++;
 
 		// Generate the cookie.
 
-		char* STR_CLEANUP cookie = NULL;
-		asprintf(&cookie, "%s/bob/aquarium.cookie.%zu.aquarium", out_path, id);
-		assert(cookie != NULL);
+		asprintf(&state->cookie, "%s/bob/aquarium.cookie.%zu.aquarium", out_path, id);
+		assert(state->cookie != NULL);
+
+		// If the cookie already exists, remove it.
+
+		if (access(state->cookie, F_OK) == 0) {
+			remove(state->cookie);
+		}
 
 		// Create the aquarium.
 
@@ -47,18 +49,18 @@ static int create_step(size_t data_count, void** data) {
 		}
 
 		cmd_add(&cmd, "create");
-		cmd_add(&cmd, cookie);
+		cmd_add(&cmd, state->cookie);
 
 		cmd_set_redirect(&cmd, false); // So we can get progress if a template needs to be downloaded e.g.
-		int rv = cmd_exec(&cmd);
+		int const rv = cmd_exec(&cmd);
 
 		if (rv == 0) {
-			set_owner(cookie);
+			set_owner(state->cookie);
 		}
 
-		cmd_log(&cmd, cookie, state->template, "create aquarium", "created aquarium", true);
+		cmd_log(&cmd, NULL, state->template, "create aquarium", "created aquarium", true);
 
-		if (rv != 0) {
+		if (rv < 0) {
 			return -1;
 		}
 	}
@@ -66,7 +68,7 @@ static int create_step(size_t data_count, void** data) {
 	return 0;
 }
 
-static int add_kernel(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+static int add_kernel(aquarium_state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 1);
 
 	if (args->args[0]->kind != FLAMINGO_VAL_KIND_STR) {
@@ -80,7 +82,7 @@ static int add_kernel(state_t* state, flamingo_arg_list_t* args, flamingo_val_t*
 	return 0;
 }
 
-static int prep_image(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+static int prep_image(aquarium_state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 0);
 
 	// TODO Imaging build step.
@@ -91,7 +93,7 @@ static int prep_image(state_t* state, flamingo_arg_list_t* args, flamingo_val_t*
 static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_val_t** rv, bool* consumed) {
 	*consumed = true;
 
-	state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
+	aquarium_state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
 
 	if (flamingo_cstrcmp(callable->name, "add_kernel", callable->name_size) == 0) {
 		return add_kernel(state, args, rv);
@@ -106,7 +108,7 @@ static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_va
 }
 
 static void free_state(flamingo_val_t* inst, void* data) {
-	state_t* const state = data;
+	aquarium_state_t* const state = data;
 
 	free(state->template);
 	free(state->kernel);
@@ -124,7 +126,7 @@ static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
 
 	// Create state object.
 
-	state_t* const state = malloc(sizeof *state);
+	aquarium_state_t* const state = malloc(sizeof *state);
 	assert(state != NULL);
 
 	state->template = strndup(args->args[0]->str.str, args->args[0]->str.size);

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -21,6 +21,11 @@
 
 typedef struct {
 	aquarium_state_t* state;
+	char* cmd;
+} exec_bss_t;
+
+typedef struct {
+	aquarium_state_t* state;
 	char* cookie;
 } image_bss_t;
 
@@ -75,6 +80,27 @@ static int create_step(size_t data_count, void** data) {
 	return 0;
 }
 
+static int exec_step(size_t data_count, void** data) {
+	for (size_t i = 0; i < data_count; i++) {
+		exec_bss_t* const bss = data[i];
+
+		LOG_INFO("%s" CLEAR ": Executing command on aquarium...", bss->state->template);
+
+		cmd_t CMD_CLEANUP cmd = {0};
+		cmd_create(&cmd, "aquarium", "enter", bss->state->cookie, NULL);
+
+		asprintf(&cmd.pending_stdin, "export HOME=/root\n%s\n", bss->cmd);
+		assert(cmd.pending_stdin != NULL);
+
+		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+		cmd_exec(&cmd);                // XXX Return values don't matter to us here, commands can fail.
+
+		cmd_log(&cmd, NULL, bss->state->template, "execute command on aquarium", "executed command on aquarium", true);
+	}
+
+	return 0;
+}
+
 static int image_step(size_t data_count, void** data) {
 	for (size_t i = 0; i < data_count; i++) {
 		image_bss_t* const bss = data[i];
@@ -114,6 +140,31 @@ static int add_kernel(aquarium_state_t* state, flamingo_arg_list_t* args, flamin
 	return 0;
 }
 
+static size_t exec_count = 0;
+
+static int prep_exec(aquarium_state_t* state, flamingo_arg_list_t* args) {
+	assert(args->count == 1);
+	flamingo_val_t* const arg = args->args[0];
+
+	if (arg->kind != FLAMINGO_VAL_KIND_STR) {
+		LOG_FATAL(AQUARIUM ": Expected argument to be string");
+		return -1;
+	}
+
+	char* const cmd = strndup(arg->str.str, arg->str.size);
+
+	// Add build step to execute on the aquarium.
+	// Order absolutely does matter here.
+
+	exec_bss_t* const bss = malloc(sizeof *bss);
+	assert(bss != NULL);
+
+	bss->state = state;
+	bss->cmd = cmd;
+
+	return add_build_step(MAGIC ^ strhash(__func__) + exec_count++, "Executing command on aquarium", exec_step, bss);
+}
+
 static int prep_image(aquarium_state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 0);
 
@@ -137,6 +188,10 @@ static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_va
 
 	if (flamingo_cstrcmp(callable->name, "add_kernel", callable->name_size) == 0) {
 		return add_kernel(state, args, rv);
+	}
+
+	else if (flamingo_cstrcmp(callable->name, "exec", callable->name_size) == 0) {
+		return prep_exec(state, args);
 	}
 
 	else if (flamingo_cstrcmp(callable->name, "image", callable->name_size) == 0) {

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -3,18 +3,68 @@
 
 #include <common.h>
 
+#include <build_step.h>
 #include <class/class.h>
+#include <cmd.h>
+#include <fsutil.h>
 #include <logging.h>
 #include <str.h>
 
 #include <assert.h>
+#include <inttypes.h>
 
 #define AQUARIUM "Aquarium"
+#define MAGIC (strhash(AQUARIUM "() magic"))
 
 typedef struct {
 	char* template;
 	char* kernel;
 } state_t;
+
+static size_t aquarium_count = 0;
+
+static int create_step(size_t data_count, void** data) {
+	for (size_t i = 0; i < data_count; i++) {
+		state_t* const state = data[i];
+		size_t id = aquarium_count++;
+
+		// Generate the cookie.
+
+		char* STR_CLEANUP cookie = NULL;
+		asprintf(&cookie, "%s/bob/aquarium.cookie.%zu.aquarium", out_path, id);
+		assert(cookie != NULL);
+
+		// Create the aquarium.
+
+		LOG_INFO("%s" CLEAR ": Creating aquarium...", state->template);
+
+		cmd_t CMD_CLEANUP cmd = {0};
+		cmd_create(&cmd, "aquarium", "-t", state->template, NULL);
+
+		if (state->kernel != NULL) {
+			cmd_add(&cmd, "-k");
+			cmd_add(&cmd, state->kernel);
+		}
+
+		cmd_add(&cmd, "create");
+		cmd_add(&cmd, cookie);
+
+		cmd_set_redirect(&cmd, false); // So we can get progress if a template needs to be downloaded e.g.
+		int rv = cmd_exec(&cmd);
+
+		if (rv == 0) {
+			set_owner(cookie);
+		}
+
+		cmd_log(&cmd, cookie, state->template, "create aquarium", "created aquarium", true);
+
+		if (rv != 0) {
+			return -1;
+		}
+	}
+
+	return 0;
+}
 
 static int add_kernel(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 1);
@@ -85,9 +135,9 @@ static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
 	inst->inst.data = state;
 	inst->inst.free_data = free_state;
 
-	// TODO Add a build step to create aquarium itself.
+	// Add build step to create aquarium itself.
 
-	return 0;
+	return add_build_step(MAGIC, "Creating aquarium", create_step, state);
 }
 
 bob_class_t BOB_CLASS_AQUARIUM = {

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#include <common.h>
+
+#include <class/class.h>
+#include <logging.h>
+#include <str.h>
+
+#include <assert.h>
+
+#define AQUARIUM "Aquarium"
+
+typedef struct {
+	char* template;
+	char* kernel;
+} state_t;
+
+static int add_kernel(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+	assert(args->count == 1);
+
+	if (args->args[0]->kind != FLAMINGO_VAL_KIND_STR) {
+		LOG_FATAL(AQUARIUM ": Expected argument to be a string");
+		return -1;
+	}
+
+	state->kernel = strndup(args->args[0]->str.str, args->args[0]->str.size);
+	assert(state->kernel != NULL);
+
+	return 0;
+}
+
+static int prep_image(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+	assert(args->count == 0);
+
+	// TODO
+
+	return 0;
+}
+
+static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_val_t** rv, bool* consumed) {
+	*consumed = true;
+
+	state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
+
+	if (flamingo_cstrcmp(callable->name, "add_kernel", callable->name_size) == 0) {
+		return add_kernel(state, args, rv);
+	}
+
+	else if (flamingo_cstrcmp(callable->name, "image", callable->name_size) == 0) {
+		return prep_image(state, args, rv);
+	}
+
+	*consumed = false;
+	return 0;
+}
+
+static void free_state(flamingo_val_t* inst, void* data) {
+	state_t* const state = data;
+
+	free(state->template);
+	free(state->kernel);
+
+	free(state);
+}
+
+static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
+	assert(args->count == 1);
+
+	if (args->args[0]->kind != FLAMINGO_VAL_KIND_STR) {
+		LOG_FATAL(AQUARIUM ": Expected argument to be a string");
+		return -1;
+	}
+
+	// Create state object.
+
+	state_t* const state = malloc(sizeof *state);
+	assert(state != NULL);
+
+	state->template = strndup(args->args[0]->str.str, args->args[0]->str.size);
+	assert(state->template != NULL);
+
+	state->kernel = NULL;
+
+	inst->inst.data = state;
+	inst->inst.free_data = free_state;
+
+	// TODO Add a build step to create aquarium itself.
+
+	return 0;
+}
+
+bob_class_t BOB_CLASS_AQUARIUM = {
+	.name = AQUARIUM,
+	.populate = NULL,
+	.call = call,
+	.instantiate = instantiate,
+};

--- a/src/class/aquarium.c
+++ b/src/class/aquarium.c
@@ -39,7 +39,7 @@ static int create_step(size_t data_count, void** data) {
 
 		// Generate the cookie.
 
-		asprintf(&state->cookie, "%s/bob/aquarium.cookie.%zu.aquarium", out_path, id);
+		asprintf(&state->cookie, "%s/aquarium.cookie.%zu.aquarium", bsys_out_path, id);
 		assert(state->cookie != NULL);
 
 		// If the cookie already exists, remove it.
@@ -63,7 +63,7 @@ static int create_step(size_t data_count, void** data) {
 		cmd_add(&cmd, "create");
 		cmd_add(&cmd, state->cookie);
 
-		cmd_set_redirect(&cmd, false); // So we can get progress if a template needs to be downloaded e.g.
+		cmd_set_redirect(&cmd, false, true); // So we can get progress if a template needs to be downloaded e.g.
 		int const rv = cmd_exec(&cmd);
 
 		if (rv == 0) {
@@ -92,8 +92,8 @@ static int exec_step(size_t data_count, void** data) {
 		asprintf(&cmd.pending_stdin, "export HOME=/root\n%s\n", bss->cmd);
 		assert(cmd.pending_stdin != NULL);
 
-		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
-		cmd_exec(&cmd);                // XXX Return values don't matter to us here, commands can fail.
+		cmd_set_redirect(&cmd, false, true); // It's nice to see these logs.
+		cmd_exec(&cmd);                      // XXX Return values don't matter to us here, commands can fail.
 
 		cmd_log(&cmd, NULL, bss->state->template, "execute command on aquarium", "executed command on aquarium", true);
 	}
@@ -109,7 +109,7 @@ static int image_step(size_t data_count, void** data) {
 
 		cmd_t CMD_CLEANUP cmd = {0};
 		cmd_create(&cmd, "aquarium", "image", bss->state->cookie, bss->cookie, NULL);
-		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+		cmd_set_redirect(&cmd, false, true); // It's nice to see these logs.
 		int rv = cmd_exec(&cmd);
 
 		if (rv == 0) {
@@ -173,7 +173,7 @@ static int prep_image(aquarium_state_t* state, flamingo_arg_list_t* args, flamin
 
 	bss->state = state;
 
-	asprintf(&bss->cookie, "%s/bob/aquarium.cookie.%zu.img", out_path, image_id++);
+	asprintf(&bss->cookie, "%s/aquarium.cookie.%zu.img", bsys_out_path, image_id++);
 	assert(bss->cookie != NULL);
 
 	*rv = flamingo_val_make_cstr(bss->cookie);

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -118,7 +118,31 @@ static int create_step(size_t data_count, void** data) {
 			return -1;
 		}
 
-		// TODO Attempt to build project.
+		// Attempt to build project.
+
+		LOG_INFO("%s" CLEAR ": Building project in the builder aquarium...", pretty);
+
+		cmd_free(&cmd);
+		cmd_create(&cmd, "aquarium", "enter", cookie, NULL);
+
+		// clang-format off
+		cmd_prepare_stdin(&cmd,
+			"set -e\n"
+			"export HOME=/root\n"
+			"export PATH\n"
+			"cd proj\n"
+			"bob build\n"
+		);
+		// clang-format on
+
+		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+
+		if (cmd_exec(&cmd) < 0) {
+			LOG_FATAL("%s" CLEAR ": Failed to build project in the builder aquarium.", pretty);
+			return -1;
+		}
+
+		LOG_SUCCESS("%s" CLEAR ": Built project in the builder aquarium.", pretty);
 	}
 
 	return 0;

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -14,7 +14,7 @@
 #include <inttypes.h>
 
 #define AQUARIUM_BUILDER "AquariumBuilder"
-#define MAGIC (strhash("AquariumBuilder() magic"))
+#define MAGIC (strhash(AQUARIUM_BUILDER "() magic"))
 
 typedef struct {
 	char* template;
@@ -52,7 +52,7 @@ static int create_step(size_t data_count, void** data) {
 		}
 
 		else {
-			LOG_INFO("%s" CLEAR ": Creating builder aquarium, as it doesn't yet exist (this might take several minutes)...", pretty);
+			LOG_INFO("%s" CLEAR ": Creating builder aquarium, as it doesn't yet exist...", pretty);
 
 			cmd_create(&cmd, "aquarium", "-t", state->template, "create", cookie, NULL);
 			cmd_set_redirect(&cmd, false); // So we can get progress if a template needs to be downloaded e.g.
@@ -62,7 +62,7 @@ static int create_step(size_t data_count, void** data) {
 				set_owner(cookie);
 			}
 
-			cmd_log(&cmd, cookie, pretty, "create builder aquarium", "created build aquarium", true);
+			cmd_log(&cmd, cookie, pretty, "create builder aquarium", "created builder aquarium", true);
 
 			if (rv != 0) {
 				return -1;

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -182,7 +182,7 @@ static int install_to_step(size_t data_count, void** data) {
 			"export HOME=/root\n"
 			"export PATH\n"
 			"cd proj\n"
-			"bob -p " INSTALL_TO_MOUNTPOINT "/usr/local install\n"
+			"bob -p " INSTALL_TO_MOUNTPOINT " install\n"
 		);
 		// clang-format on
 
@@ -201,7 +201,7 @@ static int install_to_step(size_t data_count, void** data) {
 	return 0;
 }
 
-static int prep_install_to(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+static int prep_install_to(state_t* state, flamingo_arg_list_t* args) {
 	assert(args->count == 1);
 	flamingo_val_t* const arg = args->args[0];
 
@@ -234,7 +234,7 @@ static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_va
 	state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
 
 	if (flamingo_cstrcmp(callable->name, "install_to", callable->name_size) == 0) {
-		return prep_install_to(state, args, rv);
+		return prep_install_to(state, args);
 	}
 
 	*consumed = false;

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024 Aymeric Wibo
 
-#include <class/class.h>
 #include <common.h>
+
+#include <class/class.h>
 #include <logging.h>
 #include <str.h>
 

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#include <class/class.h>
+#include <common.h>
+#include <logging.h>
+#include <str.h>
+
+#include <assert.h>
+
+#define AQUARIUM_BUILDER "AquariumBuilder"
+
+typedef struct {
+	char* template;
+	char* project_path;
+} state_t;
+
+static int prep_install_to(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
+	assert(args->count == 1);
+	flamingo_val_t* const arg = args->args[0];
+
+	if (arg->kind != FLAMINGO_VAL_KIND_INST) {
+		LOG_FATAL(AQUARIUM_BUILDER ": Expected argument to be an instance of the Aquarium class");
+		return -1;
+	}
+
+	if (flamingo_cstrcmp(arg->inst.class->name, "Aquarium", arg->inst.class->name_size) != 0) {
+		LOG_FATAL(AQUARIUM_BUILDER ": Expected argument to be an instance of the Aquarium class (is instance of '%.*s' instead)", (int) arg->inst.class->name_size, arg->inst.class->name);
+		return -1;
+	}
+
+	// TODO Installing build step.
+
+	return 0;
+}
+
+static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_val_t** rv, bool* consumed) {
+	*consumed = true;
+
+	state_t* const state = callable->owner->owner->inst.data; // TODO Should this be passed to the call function of a class?
+
+	if (flamingo_cstrcmp(callable->name, "install_to", callable->name_size) == 0) {
+		return prep_install_to(state, args, rv);
+	}
+
+	*consumed = false;
+	return 0;
+}
+
+static void free_state(flamingo_val_t* inst, void* data) {
+	state_t* const state = data;
+
+	free(state->template);
+	free(state->project_path);
+
+	free(state);
+}
+
+static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
+	assert(args->count == 2);
+
+	if (args->args[0]->kind != FLAMINGO_VAL_KIND_STR) {
+		LOG_FATAL(AQUARIUM_BUILDER ": Expected template argument to be a string");
+		return -1;
+	}
+
+	if (args->args[1]->kind != FLAMINGO_VAL_KIND_STR) {
+		LOG_FATAL(AQUARIUM_BUILDER ": Expected project path argument to be a string");
+		return -1;
+	}
+
+	// Create state object.
+
+	state_t* const state = malloc(sizeof *state);
+	assert(state != NULL);
+
+	state->template = strndup(args->args[0]->str.str, args->args[0]->str.size);
+	assert(state->template != NULL);
+
+	state->project_path = strndup(args->args[0]->str.str, args->args[0]->str.size);
+	assert(state->project_path != NULL);
+
+	inst->inst.data = state;
+	inst->inst.free_data = free_state;
+
+	// TODO Add build step to create aquarium itself.
+
+	return 0;
+}
+
+bob_class_t BOB_CLASS_AQUARIUM_BUILDER = {
+	.name = AQUARIUM_BUILDER,
+	.populate = NULL,
+	.call = call,
+	.instantiate = instantiate,
+};

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -3,18 +3,79 @@
 
 #include <common.h>
 
+#include <build_step.h>
 #include <class/class.h>
+#include <cmd.h>
+#include <fsutil.h>
 #include <logging.h>
 #include <str.h>
 
 #include <assert.h>
+#include <inttypes.h>
 
 #define AQUARIUM_BUILDER "AquariumBuilder"
+#define MAGIC (strhash("AquariumBuilder() magic"))
 
 typedef struct {
 	char* template;
 	char* project_path;
+
+	// This is the aquarium itself.
+	// It shouldn't ever be returned anywhere, so it isn't ever copied.
+
+	char* cookie;
 } state_t;
+
+typedef struct {
+	state_t* state;
+} bss_create_t;
+
+static int create_step(size_t data_count, void** data) {
+	// TODO Parallelize this, but make sure libaquarium works in parallel first.
+
+	for (size_t i = 0; i < data_count; i++) {
+		bss_create_t* const bss = data[i];
+		state_t* const state = bss->state;
+
+		// Generate the cookie.
+
+		uint64_t const hash = strhash(state->template) ^ strhash(state->project_path);
+		char* STR_CLEANUP cookie = NULL;
+		asprintf(&cookie, "%s/bob/aquarium_builder.cookie.%" PRIx64 ".aquarium", out_path, hash);
+		assert(cookie != NULL);
+
+		// If it doesn't yet exist, create the aquarium.
+
+		char* STR_CLEANUP pretty = NULL;
+		asprintf(&pretty, "Project '%s' with template '%s'", state->template, state->project_path);
+		assert(pretty != NULL);
+
+		if (access(cookie, F_OK) == 0) {
+			log_already_done(cookie, pretty, "created builder aquarium");
+		}
+
+		else {
+			LOG_INFO("%s" CLEAR ": Creating builder aquarium, as it doesn't yet exist (this might take several minutes)...", pretty);
+
+			cmd_t CMD_CLEANUP cmd;
+			cmd_create(&cmd, "aquarium", "-t", state->template, "create", cookie, NULL);
+			int const rv = cmd_exec(&cmd);
+
+			if (rv == 0) {
+				set_owner(cookie);
+			}
+
+			cmd_log(&cmd, cookie, pretty, "create builder aquarium", "created build aquarium", true);
+
+			// TODO Install Bob.
+		}
+
+		// TODO Copy/link over the project.
+		// TODO Attempt to build project.
+	}
+
+	return 0;
+}
 
 static int prep_install_to(state_t* state, flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	assert(args->count == 1);
@@ -78,15 +139,25 @@ static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
 	state->template = strndup(args->args[0]->str.str, args->args[0]->str.size);
 	assert(state->template != NULL);
 
-	state->project_path = strndup(args->args[0]->str.str, args->args[0]->str.size);
+	state->project_path = strndup(args->args[1]->str.str, args->args[1]->str.size);
 	assert(state->project_path != NULL);
 
 	inst->inst.data = state;
 	inst->inst.free_data = free_state;
 
-	// TODO Add build step to create aquarium itself.
+	// Add build step to create aquarium itself.
 
-	return 0;
+	bss_create_t* const bss = malloc(sizeof *bss);
+	assert(bss != NULL);
+
+	bss->state = state;
+
+	// We can always do this in parallel as we can have no dependencies, so let's always merge these build steps.
+	// TODO In fact, I'm pretty sure we can run all the AquariumBuilder creation build steps program-wide. We don't need other build steps to fence this.
+	// TODO Is libaquarium happy with this? Either way it's its problem if it breaks in this situation.
+	// We also don't check for frugality here, because the project might have changes, so it'll always have to be rebuilt.
+
+	return add_build_step(MAGIC, "Creating aquarium for aquarium builder", create_step, bss);
 }
 
 bob_class_t BOB_CLASS_AQUARIUM_BUILDER = {

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -26,16 +26,11 @@ typedef struct {
 	char* cookie;
 } state_t;
 
-typedef struct {
-	state_t* state;
-} bss_create_t;
-
 static int create_step(size_t data_count, void** data) {
 	// TODO Parallelize this, but make sure libaquarium works in parallel first.
 
 	for (size_t i = 0; i < data_count; i++) {
-		bss_create_t* const bss = data[i];
-		state_t* const state = bss->state;
+		state_t* const state = data[i];
 
 		// Generate the cookie.
 
@@ -217,18 +212,12 @@ static int instantiate(flamingo_val_t* inst, flamingo_arg_list_t* args) {
 	inst->inst.free_data = free_state;
 
 	// Add build step to create aquarium itself.
-
-	bss_create_t* const bss = malloc(sizeof *bss);
-	assert(bss != NULL);
-
-	bss->state = state;
-
 	// We can always do this in parallel as we can have no dependencies, so let's always merge these build steps.
 	// TODO In fact, I'm pretty sure we can run all the AquariumBuilder creation build steps program-wide. We don't need other build steps to fence this.
 	// TODO Is libaquarium happy with this? Either way it's its problem if it breaks in this situation.
 	// We also don't check for frugality here, because the project might have changes, so it'll always have to be rebuilt.
 
-	return add_build_step(MAGIC, "Creating aquarium for aquarium builder", create_step, bss);
+	return add_build_step(MAGIC, "Creating aquarium for aquarium builder", create_step, state);
 }
 
 bob_class_t BOB_CLASS_AQUARIUM_BUILDER = {

--- a/src/class/aquarium_builder.c
+++ b/src/class/aquarium_builder.c
@@ -43,7 +43,7 @@ static int create_step(size_t data_count, void** data) {
 		// Generate the cookie.
 
 		uint64_t const hash = strhash(state->template) ^ strhash(state->overlays) ^ strhash(state->project_path);
-		asprintf(&state->cookie, "%s/bob/aquarium_builder.cookie.%" PRIx64 ".aquarium", out_path, hash);
+		asprintf(&state->cookie, "%s/aquarium_builder.cookie.%" PRIx64 ".aquarium", bsys_out_path, hash);
 		assert(state->cookie != NULL);
 
 		// If it doesn't yet exist, create the aquarium.
@@ -71,7 +71,7 @@ static int create_step(size_t data_count, void** data) {
 			cmd_add(&cmd, "create");
 			cmd_add(&cmd, state->cookie);
 
-			cmd_set_redirect(&cmd, false); // So we can get progress if a template needs to be downloaded e.g.
+			cmd_set_redirect(&cmd, false, false); // So we can get progress if a template needs to be downloaded e.g.
 			int rv = cmd_exec(&cmd);
 
 			if (rv == 0) {
@@ -104,7 +104,7 @@ static int create_step(size_t data_count, void** data) {
 			);
 			// clang-format on
 
-			cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+			cmd_set_redirect(&cmd, false, false); // It's nice to see these logs.
 
 			if (cmd_exec(&cmd) < 0) {
 				LOG_FATAL("%s" CLEAR ": Failed to install Bob to the builder aquarium.", pretty);
@@ -146,7 +146,7 @@ static int create_step(size_t data_count, void** data) {
 		);
 		// clang-format on
 
-		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+		cmd_set_redirect(&cmd, false, false); // It's nice to see these logs.
 
 		if (cmd_exec(&cmd) < 0) {
 			LOG_FATAL("%s" CLEAR ": Failed to build project in the builder aquarium.", pretty);
@@ -196,7 +196,7 @@ static int install_to_step(size_t data_count, void** data) {
 		);
 		// clang-format on
 
-		cmd_set_redirect(&cmd, false); // It's nice to see these logs.
+		cmd_set_redirect(&cmd, false, false); // It's nice to see these logs.
 
 		if (cmd_exec(&cmd) < 0) {
 			LOG_FATAL("%s" CLEAR ": Failed to install built project to target aquarium.", bss->state->template);

--- a/src/class/aquarium_common.h
+++ b/src/class/aquarium_common.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#pragma once
+
+typedef struct {
+	char* template;
+	char* kernel;
+
+	// Set but not used by Aquarium.
+
+	char* cookie;
+} aquarium_state_t;
+
+// TODO Put the preliminary aquarium check in here as a simple inline function.

--- a/src/class/class.h
+++ b/src/class/class.h
@@ -14,6 +14,7 @@ typedef struct {
 	int (*instantiate)(flamingo_val_t* inst, flamingo_arg_list_t* args);
 } bob_class_t;
 
+extern bob_class_t BOB_CLASS_AQUARIUM;
 extern bob_class_t BOB_CLASS_CC;
 extern bob_class_t BOB_CLASS_CARGO;
 extern bob_class_t BOB_CLASS_FS;
@@ -23,6 +24,7 @@ extern bob_class_t BOB_CLASS_PKG_CONFIG;
 extern bob_class_t BOB_CLASS_PLATFORM;
 
 static bob_class_t* const BOB_CLASSES[] = {
+	&BOB_CLASS_AQUARIUM,
 	&BOB_CLASS_CC,
 	&BOB_CLASS_CARGO,
 	&BOB_CLASS_FS,

--- a/src/class/class.h
+++ b/src/class/class.h
@@ -15,6 +15,7 @@ typedef struct {
 } bob_class_t;
 
 extern bob_class_t BOB_CLASS_AQUARIUM;
+extern bob_class_t BOB_CLASS_AQUARIUM_BUILDER;
 extern bob_class_t BOB_CLASS_CC;
 extern bob_class_t BOB_CLASS_CARGO;
 extern bob_class_t BOB_CLASS_FS;
@@ -25,6 +26,7 @@ extern bob_class_t BOB_CLASS_PLATFORM;
 
 static bob_class_t* const BOB_CLASSES[] = {
 	&BOB_CLASS_AQUARIUM,
+	&BOB_CLASS_AQUARIUM_BUILDER,
 	&BOB_CLASS_CC,
 	&BOB_CLASS_CARGO,
 	&BOB_CLASS_FS,


### PR DESCRIPTION
Resolves #33 
Also see https://github.com/inobulles/aquarium/pull/48

To do:

- [x] `AquariumBuilder` class.
- [x] `Aquarium` class.
- [x] Preemptive check for if aquariums are installed, so we don't run any of the build steps (can just do a list command and see if that fails ig).
- [x] Put the aquarium Bob stuff in `bob.aquarium` I guess.
- [ ] Look through TODO's in added code cuh I'm pretty sure there's a bunch of important stuff I forgot.
- [ ] Figure out where to put `root.img` and `esp.img` temporary artifacts (should aquariums just be responsible for these and put them in `/usr/local/aquarium` somewhere?).
- [x] ~Find an elegant way to output artifacts, like `bob out bootable.img` or something, and an `out` value which just takes in a cookie you wanna use (probably in it's own PR before this one). Alternatively, I could have an "artifacts" system with an artifacts map.~ Done, #148 
- [x] ~Update the `VERSION` `#define` and maybe add a CI check for this.~ Done in #122 (although maybe I'll want it to be minus 1 instead...).

It's infeasible to do tests on this in Bob. But since I want all aquariums to move to being built by Bob, tests for aquariums will naturally test for the Bob implementation too (I wonder if there's a standard way to trigger CI on other projects dependant projects? because then this could be automated).