### PR TITLE
`Cargo` class

### DIFF
--- a/build.fl
+++ b/build.fl
@@ -17,6 +17,7 @@ let cmd = Linker(["-lm", "-lpthread"]).link(obj)
 install = {
 	cmd: "bin/bob",
 	"import/bob.fl": "share/flamingo/import/bob.fl",
+	"import/bob": "share/flamingo/import/bob",
 	"skeletons": "share/bob/skeletons",
 }
 

--- a/import/bob/cargo.fl
+++ b/import/bob/cargo.fl
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2024 Aymeric Wibo
+
+class Cargo {
+	static proto build -> str
+}

--- a/src/class/cargo.c
+++ b/src/class/cargo.c
@@ -34,7 +34,14 @@ static int build_step(size_t data_count, void** data) {
 
 static int build(flamingo_arg_list_t* args, flamingo_val_t** rv) {
 	if (args->count != 0) {
-		LOG_FATAL(CARGO ".build: Didn't expect any arguments, got %zu", args->count);
+		LOG_FATAL(CARGO ".build: Didn't expect any arguments, got %zu.", args->count);
+		return -1;
+	}
+
+	// Check for cargo executable.
+
+	if (!cmd_exists("cargo")) {
+		LOG_FATAL(CARGO ".build: Couldn't find 'cargo' executable in PATH. Cargo is something you must install separately.");
 		return -1;
 	}
 

--- a/src/class/cargo.c
+++ b/src/class/cargo.c
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024 Aymeric Wibo
+
+#include <common.h>
+
+#include <build_step.h>
+#include <class/class.h>
+#include <cmd.h>
+#include <logging.h>
+#include <str.h>
+
+#define CARGO "Cargo"
+
+static flamingo_val_t* build_val = NULL;
+
+static int build_step(size_t data_count, void** data) {
+	if (data_count != 1) {
+		LOG_FATAL(CARGO ".build can't be called more than once (was called %zu times).", data_count);
+		return -1;
+	}
+
+	// Run "cargo build".
+
+	LOG_INFO(CARGO ": Building...");
+
+	cmd_t CMD_CLEANUP cmd = {0};
+	cmd_create(&cmd, "cargo", "build", NULL);
+
+	int const rv = cmd_exec(&cmd);
+	cmd_log(&cmd, NULL, "Cargo project", "build", "built", true);
+
+	return rv;
+}
+
+static int build(flamingo_arg_list_t* args, flamingo_val_t** rv) {
+	if (args->count != 0) {
+		LOG_FATAL(CARGO ".build: Didn't expect any arguments, got %zu", args->count);
+		return -1;
+	}
+
+	// Return "target" directory.
+	// We don't attempt to put this in '.bob' so we don't interfere with existing tooling (like LSPs and stuff).
+
+	*rv = flamingo_val_make_cstr("target/release/");
+
+	// Add build step.
+
+	return add_build_step(strhash(CARGO), "Cargo build", build_step, NULL);
+}
+
+static void populate(char* key, size_t key_size, flamingo_val_t* val) {
+	if (flamingo_cstrcmp(key, "build", key_size) == 0) {
+		build_val = val;
+	}
+}
+
+static int call(flamingo_val_t* callable, flamingo_arg_list_t* args, flamingo_val_t** rv, bool* consumed) {
+	*consumed = true;
+
+	if (callable == build_val) {
+		return build(args, rv);
+	}
+
+	*consumed = false;
+	return 0;
+}
+
+bob_class_t BOB_CLASS_CARGO = {
+	.name = CARGO,
+	.populate = populate,
+	.call = call,
+};

--- a/src/class/class.h
+++ b/src/class/class.h
@@ -15,12 +15,14 @@ typedef struct {
 } bob_class_t;
 
 extern bob_class_t BOB_CLASS_CC;
+extern bob_class_t BOB_CLASS_CARGO;
 extern bob_class_t BOB_CLASS_FS;
 extern bob_class_t BOB_CLASS_LINKER;
 extern bob_class_t BOB_CLASS_PLATFORM;
 
 static bob_class_t* const BOB_CLASSES[] = {
 	&BOB_CLASS_CC,
+	&BOB_CLASS_CARGO,
 	&BOB_CLASS_FS,
 	&BOB_CLASS_LINKER,
 	&BOB_CLASS_PLATFORM,

--- a/src/cmd.h
+++ b/src/cmd.h
@@ -35,6 +35,8 @@ void cmd_add_argv(cmd_t* cmd, int argc, char* argv[]);
 void cmd_set_redirect(cmd_t* cmd, bool redirect);
 void cmd_prepare_stdin(cmd_t* cmd, char* data);
 
+bool cmd_exists(char const* cmd);
+
 int cmd_exec_inplace(cmd_t* cmd);
 pid_t cmd_exec_async(cmd_t* cmd);
 int cmd_exec(cmd_t* cmd);


### PR DESCRIPTION
Simple class to build Rust projects using Cargo.

This is NOT the planned Cargo bsys! That will be using Bob as a frontend to existing Cargo projects, such that they can directly be used as dependencies.

Instead, this is a class for Bob projects which use Cargo too (useful if you need to install shared libraries for instance, which Cargo does not itself support).