### PR TITLE
dep-tree: Force whole dependency tree rebuilding if hash file missing

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -32,3 +32,5 @@ extern _Bool own_prefix;
 extern char const* install_prefix;
 extern char* default_final_install_prefix;
 extern char* default_tmp_install_prefix;
+
+extern _Bool force_dep_tree_rebuild;

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,8 @@ char const* install_prefix = NULL;
 char* default_final_install_prefix = NULL;
 char* default_tmp_install_prefix = NULL;
 
+bool force_dep_tree_rebuild = false;
+
 bool running_as_root = false;
 uid_t owner = 0;
 
@@ -79,7 +81,7 @@ int main(int argc, char* argv[]) {
 
 	int c;
 
-	while ((c = getopt(argc, argv, "C:Dj:Oo:p:")) != -1) {
+	while ((c = getopt(argc, argv, "C:Dfj:Oo:p:")) != -1) {
 		switch (c) {
 		case 'C':
 			project_path = optarg;
@@ -101,6 +103,9 @@ int main(int argc, char* argv[]) {
 			break;
 		case 'p':
 			install_prefix = optarg;
+			break;
+		case 'f':
+			force_dep_tree_rebuild = true;
 			break;
 		default:
 			usage();


### PR DESCRIPTION
Fixes #89 