### PR TITLE
main: Rebuild on version change

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -56,14 +56,14 @@ extern char const* init_name;
 extern char const* bootstrap_import_path;
 
 /**
- * The absolute ".bob" output path.
+ * The absolute ".bob/$TARGET/" output path.
  */
 extern char const* abs_out_path;
 
 /**
  * The current build system's output path, including the ".bob" prefix.
  *
- * E.g. ".bob/bob/", or ".bob/meson/".
+ * E.g. ".bob/$TARGET/bob/", or ".bob/$TARGET/meson/".
  */
 extern char* bsys_out_path;
 
@@ -96,7 +96,7 @@ extern char* default_final_install_prefix;
 /**
  * Default temporary installation prefix.
  *
- * Set to '.bob/prefix/' (depending on the value of {@link abs_out_path}).
+ * Set to '.bob/$TARGET/prefix/' (depending on the value of {@link abs_out_path}).
  */
 extern char* default_tmp_install_prefix;
 

--- a/src/common.h
+++ b/src/common.h
@@ -24,6 +24,14 @@
 #define VERSION "v0.2.24"
 
 /**
+ * Bob build ID.
+ *
+ * This is a combination of the current Bob version and date & time of the build.
+ * It is saved to the output directory and the dependency cache directory, and if it changes, the dependency cache directory is cleared and the full project rebuilt.
+ */
+#define BUILD_ID VERSION "\t" __DATE__ "\t" __TIME__
+
+/**
  * Whether the BOB_BUIlD_DEBUGGING envvar is set.
  */
 extern _Bool debugging;

--- a/src/main.c
+++ b/src/main.c
@@ -75,7 +75,7 @@ void usage(void) {
 	exit(EXIT_FAILURE);
 }
 
-static void get_deps_path(void) {
+static int get_and_ensure_deps_path(void) {
 	deps_path = getenv("BOB_DEPS_PATH");
 
 	if (deps_path == NULL) {
@@ -94,6 +94,15 @@ static void get_deps_path(void) {
 
 		assert(deps_path != NULL);
 	}
+
+	// Ensure it exists.
+
+	if (mkdir_recursive(deps_path, 0755) < 0) {
+		LOG_FATAL("mkdir_recursive(\"%s\"): %s", deps_path, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }
 
 int main(int argc, char* argv[]) {
@@ -302,14 +311,9 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	// Get the dependencies path.
+	// Get the dependencies path and ensure it exists.
 
-	get_deps_path();
-
-	// Ensure it exists.
-
-	if (mkdir_recursive(deps_path, 0755) < 0) {
-		LOG_FATAL("mkdir_recursive(\"%s\"): %s", deps_path, strerror(errno));
+	if (get_and_ensure_deps_path() < 0) {
 		return EXIT_FAILURE;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -158,6 +158,7 @@ clear:
 
 	fputs(BUILD_ID, new_version_f);
 	fclose(new_version_f);
+	set_owner(version_path);
 
 	return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -135,7 +135,6 @@ static int clear_out_path_if_bob_update(void) {
 
 	// Otherwise, just return now.
 
-	fclose(f);
 	return 0;
 
 clear:

--- a/src/main.c
+++ b/src/main.c
@@ -8,6 +8,7 @@
 #include <fsutil.h>
 #include <logging.h>
 #include <ncpu.h>
+#include <str.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -101,6 +102,63 @@ static int get_and_ensure_deps_path(void) {
 		LOG_FATAL("mkdir_recursive(\"%s\"): %s", deps_path, strerror(errno));
 		return -1;
 	}
+
+	return 0;
+}
+
+static int clear_out_path_if_bob_update(void) {
+	char* STR_CLEANUP err = NULL;
+
+	char* STR_CLEANUP version_path = NULL;
+	asprintf(&version_path, "%s/version", abs_out_path);
+	assert(version_path != NULL);
+
+	FILE* const f = fopen(version_path, "r");
+
+	// If version file doesn't exist, clear cache.
+	// Don't log here, because it might just be the first time creating this directory.
+
+	if (f == NULL) {
+		goto clear;
+	}
+
+	// If stored version changed, clear cache.
+
+	char stored[64] = {0};
+	fread(stored, 1, sizeof stored - 1, f);
+	fclose(f);
+
+	if (strcmp(stored, BUILD_ID) != 0) {
+		LOG_WARN("Bob was updated, clearing output path.");
+		goto clear;
+	}
+
+	// Otherwise, just return now.
+
+	fclose(f);
+	return 0;
+
+clear:
+
+	if (rm(abs_out_path, &err) < 0) {
+		LOG_FATAL("Failed to clear output path (\"%s\"): %s", abs_out_path, err);
+		return -1;
+	}
+
+	if (mkdir_recursive(abs_out_path, 0755) < 0) {
+		LOG_FATAL("mkdir_recursive(\"%s\"): %s", abs_out_path, strerror(errno));
+		return -1;
+	}
+
+	FILE* const new_version_f = fopen(version_path, "w");
+
+	if (new_version_f == NULL) {
+		LOG_FATAL("fopen(\"%s\"): %s", version_path, strerror(errno));
+		return -1;
+	}
+
+	fputs(BUILD_ID, new_version_f);
+	fclose(new_version_f);
 
 	return 0;
 }
@@ -284,9 +342,17 @@ int main(int argc, char* argv[]) {
 		return EXIT_FAILURE;
 	}
 
+	// Clear output directory if the Bob build ID changed.
+	// Has to be done before we ensure the temporary installation prefix exists, or we might remove it and it won't be recreated.
+
+	if (clear_out_path_if_bob_update() < 0) {
+		return EXIT_FAILURE;
+	}
+
 	// Get default final and temporary install prefixes.
 
 	default_final_install_prefix = "/usr/local";
+
 	asprintf(&default_tmp_install_prefix, "%s/prefix", abs_out_path);
 	assert(default_tmp_install_prefix != NULL);
 

--- a/src/main.c
+++ b/src/main.c
@@ -129,7 +129,7 @@ static int clear_out_path_if_bob_update(void) {
 	fclose(f);
 
 	if (strcmp(stored, BUILD_ID) != 0) {
-		LOG_WARN("Bob was updated, clearing output path.");
+		LOG_INFO("Bob was updated, clearing output path.");
 		goto clear;
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -165,7 +165,7 @@ clear:
 
 int main(int argc, char* argv[]) {
 	init_name = argv[0];
-	char* out_path = ".bob"; // Default output path (without target).
+	char* out_path = ".bob"; // Default output path (without target, for now).
 	char const* project_path = NULL;
 	logging_init();
 
@@ -373,7 +373,7 @@ int main(int argc, char* argv[]) {
 
 		if (mkdir_recursive(prefix, 0755) < 0 && errno != EEXIST) {
 			LOG_FATAL("mkdir(\"%s\"): %s", prefix, strerror(errno));
-			return -1;
+			return EXIT_FAILURE;
 		}
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -75,6 +75,27 @@ void usage(void) {
 	exit(EXIT_FAILURE);
 }
 
+static void get_deps_path(void) {
+	deps_path = getenv("BOB_DEPS_PATH");
+
+	if (deps_path == NULL) {
+		char const* const home = getenv("HOME");
+
+		// XXX Don't worry about freeing these.
+
+		if (home != NULL) {
+			asprintf(&deps_path, "%s/%s", home, ".cache/bob/deps");
+		}
+
+		else {
+			asprintf(&deps_path, "%s/%s", abs_out_path, "deps");
+			LOG_WARN("$HOME is not set, using '%s' as the dependencies path as a last resort.", deps_path);
+		}
+
+		assert(deps_path != NULL);
+	}
+}
+
 int main(int argc, char* argv[]) {
 	init_name = argv[0];
 	char* out_path = ".bob"; // Default output path (without target).
@@ -283,24 +304,7 @@ int main(int argc, char* argv[]) {
 
 	// Get the dependencies path.
 
-	deps_path = getenv("BOB_DEPS_PATH");
-
-	if (deps_path == NULL) {
-		char const* const home = getenv("HOME");
-
-		// XXX Don't worry about freeing these.
-
-		if (home != NULL) {
-			asprintf(&deps_path, "%s/%s", home, ".cache/bob/deps");
-		}
-
-		else {
-			asprintf(&deps_path, "%s/%s", abs_out_path, "deps");
-			LOG_WARN("$HOME is not set, using '%s' as the dependencies path as a last resort.", deps_path);
-		}
-
-		assert(deps_path != NULL);
-	}
+	get_deps_path();
 
 	// Ensure it exists.
 

--- a/src/main.c
+++ b/src/main.c
@@ -313,10 +313,6 @@ int main(int argc, char* argv[]) {
 		return EXIT_FAILURE;
 	}
 
-	// TODO Make sure relative bin path is in '.gitignore'.
-
-	// validate_gitignore((char*) rel_bin_path);
-
 	// Identify the build system.
 
 	bsys_t const* const bsys = bsys_identify();

--- a/tests/invalidate_cache_if_bob_updated.sh
+++ b/tests/invalidate_cache_if_bob_updated.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+. tests/common.sh
+
+VERSION_FILE=tests/fs/.bob/$BOB_TARGET/version
+
+# Fresh build: version file should be created.
+
+rm -rf tests/fs/.bob
+
+bob -C tests/fs build > /dev/null 2>&1
+
+[ -f $VERSION_FILE ]
+[ -s $VERSION_FILE ]
+
+# Same version: no "Bob was updated" warning.
+
+out=$(bob -C tests/fs build 2>&1)
+
+echo "$out" | grep -qv "Bob was updated"
+
+# Stale version file: should warn and clear the cache.
+
+echo "old-version" > $VERSION_FILE
+
+out=$(bob -C tests/fs build 2>&1)
+
+echo "$out" | grep -q "Bob was updated"
+
+[ -f $VERSION_FILE ]
+[ "$(cat $VERSION_FILE)" != "old-version" ]


### PR DESCRIPTION
Resolves #32 

To do:

- [x] ~We should also track the version of the dependencies cache and clear it if there's a version change.~ Actually no, we don't want this, because each dependency is already tracking this and all this would do is reclone git dependencies (which we don't necessarily want, at least not from this).
- [x] Tests. 