### PR TITLE
Make sure output path is in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ compile_commands.json
 .bob
 .bootstrap
 .test-out
+.test-out/test-bob
+.test-out/test-bob2
 tests/deps/build.fl
 tests/static_link/custom_l/custom-libs/
 tests/static_link/shared/fake-libs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,5 @@
-bin
-sh-bin
 *.sw[op]
 *.core
-*.zpk
-Cargo.toml
-Cargo.lock
-target
 compile_commands.json
 .cache
 .bob

--- a/src/common.h
+++ b/src/common.h
@@ -21,7 +21,7 @@
  *
  * Should always be one higher than the latest tag, unless we are the commit of that tag itself.
  */
-#define VERSION "v0.2.24"
+#define VERSION "v0.2.25"
 
 /**
  * Bob build ID.

--- a/src/common.h
+++ b/src/common.h
@@ -56,6 +56,11 @@ extern char const* init_name;
 extern char const* bootstrap_import_path;
 
 /**
+ * The top-level ".bob" (without target subdir) output path.
+ */
+extern char const* targetless_out_path;
+
+/**
  * The absolute ".bob/$TARGET/" output path.
  */
 extern char const* abs_out_path;

--- a/src/fsutil.h
+++ b/src/fsutil.h
@@ -12,4 +12,11 @@ int would_set_owner(char const* path, bool* would);
 int set_owner(char const* path);
 int mkdir_wrapped(char const* path, mode_t mode);
 int mkdir_recursive(char const* path, mode_t mode);
+
+/**
+ * Like realpath(3), but also expands a leading '~' to $HOME.
+ *
+ * @param path Path to resolve.
+ * @return Resolved absolute path (heap-allocated), or NULL if resolution failed or $HOME is unset when path starts with '~'.
+ */
 char* realerpath(char const* path);

--- a/src/gitignore.c
+++ b/src/gitignore.c
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Aymeric Wibo
+
+#include <common.h>
+
+#include <fsutil.h>
+#include <logging.h>
+#include <str.h>
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+void check_gitignore(void) {
+	// Only relevant in a git repo.
+
+	if (access(".git", F_OK) != 0) {
+		return;
+	}
+
+	FILE* const f = fopen(".gitignore", "r");
+
+	if (f == NULL) {
+		LOG_WARN("No .gitignore found. Consider creating it with \"%s\" in it.", targetless_out_path);
+		return;
+	}
+
+	char* STR_CLEANUP real_out_path = realerpath(targetless_out_path);
+	assert(real_out_path != NULL);
+
+	char* STR_CLEANUP line = NULL; // getline(3) is weird but... trust this is correct, and we don't needa realloc or anything.
+	size_t len = 0;
+	bool found = false;
+	size_t line_count = 0;
+
+	while (getline(&line, &len, f) != -1) {
+		// Done because I'm scared of the perf implications of this.
+
+		if (++line_count > 1000) {
+			LOG_WARN("what's wrong with you?");
+			break;
+		}
+
+		line[strlen(line) - 1] = '\0'; // Remove newline that getline(3) keeps for some reason.
+
+		char* STR_CLEANUP real_gitignore_path = realerpath(line);
+
+		if (real_gitignore_path == NULL) {
+			continue;
+		}
+
+		if (strcmp(real_out_path, real_gitignore_path) == 0) {
+			found = true;
+			break;
+		}
+	}
+
+	fclose(f);
+
+	if (!found) {
+		LOG_WARN("\"%s\" is not in .gitignore. Consider adding it.", targetless_out_path);
+	}
+}

--- a/src/gitignore.h
+++ b/src/gitignore.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 Aymeric Wibo
+
+#pragma once
+
+/**
+ * Check that the output path is listed in .gitignore.
+ *
+ * Warns if .gitignore doesn't exist or if out_path is not found in it.
+ *
+ * @param out_path Output path to look for (e.g. ".bob").
+ */
+void check_gitignore(char const* out_path);

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
 #include <bsys.h>
 #include <build_step.h>
 #include <fsutil.h>
+#include <gitignore.h>
 #include <logging.h>
 #include <ncpu.h>
 #include <str.h>
@@ -478,6 +479,11 @@ int main(int argc, char* argv[]) {
 	}
 
 	free_build_steps();
+
+	// Check output path is in .gitignore.
+	// Done last so the message isn't buried under build output.
+
+	check_gitignore(targetless_out_path);
 
 	return rv;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2023-2025 Aymeric Wibo
+// Copyright (c) 2023-2026 Aymeric Wibo
 
 #include <common.h>
 
@@ -31,6 +31,7 @@ bool debugging = false;
 char const* init_name = "bob";
 char const* bootstrap_import_path = "import";
 
+char const* targetless_out_path = NULL;
 char const* abs_out_path = NULL;
 char* bsys_out_path = NULL;
 
@@ -165,7 +166,7 @@ clear:
 
 int main(int argc, char* argv[]) {
 	init_name = argv[0];
-	char* out_path = ".bob"; // Default output path (without target, for now).
+	targetless_out_path = ".bob"; // Default output path.
 	char const* project_path = NULL;
 	logging_init();
 
@@ -191,7 +192,7 @@ int main(int argc, char* argv[]) {
 			own_prefix = true;
 			break;
 		case 'o':
-			out_path = optarg;
+			targetless_out_path = optarg;
 			break;
 		case 'p':
 			install_prefix = optarg;
@@ -300,8 +301,8 @@ int main(int argc, char* argv[]) {
 
 	// Ensure the output path exists.
 
-	if (mkdir_wrapped(out_path, 0755) < 0 && errno != EEXIST) {
-		LOG_FATAL("mkdir(\"%s\"): %s", out_path, strerror(errno));
+	if (mkdir_wrapped(targetless_out_path, 0755) < 0 && errno != EEXIST) {
+		LOG_FATAL("mkdir(\"%s\"): %s", targetless_out_path, strerror(errno));
 		return EXIT_FAILURE;
 	}
 
@@ -323,7 +324,9 @@ int main(int argc, char* argv[]) {
 		}
 	}
 
-	asprintf(&out_path, "%s/%s", out_path, target);
+	char* STR_CLEANUP out_path = NULL;
+
+	asprintf(&out_path, "%s/%s", targetless_out_path, target);
 	assert(out_path != NULL);
 
 	// Ensure the target path exists too.

--- a/tests/dummy/build.fl
+++ b/tests/dummy/build.fl
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Aymeric Wibo
+
+import bob
+
+# Literally meant to be the bare minimum possible Bob project.
+# I don't even know why I'm bothering with a license header, pretty sure this isn't copyrightable lolz.

--- a/tests/gitignore.sh
+++ b/tests/gitignore.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -e
+
+. tests/common.sh
+
+DIR=tests/dummy
+
+cleanup() {
+	rm -f $DIR/.gitignore
+	rm -rf $DIR/.git
+}
+
+cleanup
+trap cleanup EXIT # Cleans up when the program exits.
+
+echo "Testing: no .git: no warning regardless."
+
+out=$(bob -C $DIR build 2>&1)
+echo "$out" | grep -qv "gitignore"
+
+echo "Testing: .git but no .gitignore: warn."
+
+mkdir $DIR/.git
+out=$(bob -C $DIR build 2>&1)
+echo "$out" | grep -q "No .gitignore found"
+
+echo "Testing: .gitignore without .bob: warn."
+
+echo "something_else" > $DIR/.gitignore
+out=$(bob -C $DIR build 2>&1)
+echo "$out" | grep -q "is not in .gitignore"
+
+echo "Testing: .gitignore with .bob: no warning."
+
+echo ".bob" >> $DIR/.gitignore
+out=$(bob -C $DIR build 2>&1)
+echo "$out" | grep -qv "gitignore"


### PR DESCRIPTION
Resolves #125

This is not yet perfect, because technically we could have a `.gitignore` file in a higher-level directory, but eh I'm fine with leaving this as is until this annoys me enough to change (may need to do that with [aqua](https://github.com/inobulles/aqua) now I think about it.

Also I realize this doesn't take into account if like the `.bob` is in a subdir, which means `tests/bob.sh` spits out warnings... ngl I don't care enough to actually fix this.

Also also technically this doesn't cover more complex rules like idk `.bo[bd]`, but idk why anyone would do this.

Also I would like to note how utterly useless Claude Code was at implementing any of this... I swear it gets stupider the more I use it.