### PR TITLE
dep: Dependency configuration

### DIFF
--- a/import/bob.fl
+++ b/import/bob.fl
@@ -22,6 +22,7 @@ class Dep(_kind: str) {
 	# Config.
 
 	let build_path = ""
+	let config: map<str, str> = {}
 
 	# Constructors.
 
@@ -42,6 +43,11 @@ class Dep(_kind: str) {
 
 	fn cd(path: str) -> Dep {
 		build_path = path
+		return self
+	}
+
+	fn conf(key: str, val: str) -> Dep {
+		config[key] = val
 		return self
 	}
 }

--- a/src/bsys.h
+++ b/src/bsys.h
@@ -13,6 +13,11 @@ struct bsys_t {
 	char const* name;
 	char const* key;
 
+	/**
+	 * Whether this build system supports config options passed via -D KEY=VAL.
+	 */
+	bool supports_config;
+
 	bool (*identify)(void);
 	int (*setup)(void);
 	dep_node_t* (*dep_tree)(size_t path_len, uint64_t* path_hashes, bool* circular);

--- a/src/bsys/cmake/main.c
+++ b/src/bsys/cmake/main.c
@@ -31,6 +31,10 @@ static int configure(void) {
 
 	cmd_addf(&cmd, "-DCMAKE_INSTALL_PREFIX=%s", install_prefix);
 
+	for (size_t i = 0; i < dep_config_count; i++) {
+		cmd_addf(&cmd, "-D%s=%s", dep_config_keys[i], dep_config_vals[i]);
+	}
+
 	if (cmd_exists("ninja")) {
 		cmd_add(&cmd, "-GNinja");
 	}

--- a/src/bsys/cmake/main.c
+++ b/src/bsys/cmake/main.c
@@ -87,6 +87,7 @@ static int install(void) {
 bsys_t const BSYS_CMAKE = {
 	.name = "CMake",
 	.key = "cmake",
+	.supports_config = true,
 	.identify = identify,
 	.setup = setup,
 	.build = build,

--- a/src/class/linker.c
+++ b/src/class/linker.c
@@ -205,7 +205,7 @@ static int prep_link(state_t* state, flamingo_arg_list_t* args, flamingo_val_t**
 
 		// XOR'ing makes sure order doesn't matter.
 
-		total_hash ^= str_hash(src->str.str, src->str.size);
+		total_hash ^= strnhash(src->str.str, src->str.size);
 	}
 
 	char* STR_CLEANUP cookie = NULL;

--- a/src/common.h
+++ b/src/common.h
@@ -14,6 +14,8 @@
 # define _GNU_SOURCE
 #endif
 
+#include <sys/types.h>
+
 #define COMMON_INCLUDED
 
 /**
@@ -119,3 +121,12 @@ extern char const* install_prefix;
  * Used to propagate dependency tree rebuild through all children processes.
  */
 extern _Bool force_dep_tree_rebuild;
+
+/**
+ * Config map passed by the parent to this dependency via -c KEY=VAL flags.
+ *
+ * Each build system backend that supports configuration (e.g. CMake via -D) reads these.
+ */
+extern size_t dep_config_count;
+extern char** dep_config_keys;
+extern char** dep_config_vals;

--- a/src/common.h
+++ b/src/common.h
@@ -21,7 +21,7 @@
  *
  * Should always be one higher than the latest tag, unless we are the commit of that tag itself.
  */
-#define VERSION "v0.2.25"
+#define VERSION "v0.2.26"
 
 /**
  * Bob build ID.

--- a/src/cookie.c
+++ b/src/cookie.c
@@ -15,7 +15,7 @@
 
 char* gen_cookie(char* path, size_t path_size, char const* ext) {
 	char* cookie = NULL;
-	asprintf(&cookie, "%s/%.*s.cookie.%" PRIx64 ".%s", bsys_out_path, (int) path_size, path, str_hash(path, path_size), ext);
+	asprintf(&cookie, "%s/%.*s.cookie.%" PRIx64 ".%s", bsys_out_path, (int) path_size, path, strnhash(path, path_size), ext);
 	assert(cookie != NULL);
 
 	size_t const prefix_len = strlen(bsys_out_path) + strlen("/");

--- a/src/dep_serialization.c
+++ b/src/dep_serialization.c
@@ -1,6 +1,18 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2025 Aymeric Wibo
 
+/*
+ * Sereal and a coffee.
+ *
+ *   ;)( ;
+ *  :----:     o8Oo./
+ * C|====| ._o8o8o8Oo_.
+ *  |    |  \========/
+ *  `----'   `------'
+ *
+ * Hayley Jane Wakenshaw (Flump)
+ */
+
 #include <common.h>
 #include <deps.h>
 #include <logging.h>
@@ -45,8 +57,22 @@ static char* serialize_inner(dep_node_t* node, size_t depth) {
 	memset(depth_chars, DEPTH_CHAR, depth);
 
 	char* serialized = NULL;
-	asprintf(&serialized, "%s%d:%s:%s:%s\n", depth_chars, node->kind, node->human, node->path, node->build_path);
+	asprintf(&serialized, "%s%d:%s:%s:%s:%zu", depth_chars, node->kind, node->human, node->path, node->build_path, node->config_key_count);
 	assert(serialized != NULL);
+
+	for (size_t i = 0; i < node->config_key_count; i++) {
+		char* tmp;
+		asprintf(&tmp, "%s:%s:%s", serialized, node->config_keys[i], node->config_vals[i]);
+		assert(tmp != NULL);
+		free(serialized);
+		serialized = tmp;
+	}
+
+	char* tmp;
+	asprintf(&tmp, "%s\n", serialized);
+	assert(tmp != NULL);
+	free(serialized);
+	serialized = tmp;
 
 	return add_children(serialized, node, depth + 1);
 }
@@ -175,6 +201,27 @@ int dep_node_deserialize(dep_node_t* root, char* serialized) {
 			return -1;
 		}
 
+		// Read config map.
+
+		char* const config_count_str = strsep(&tuple, ":");
+		size_t const config_key_count = config_count_str == NULL ? 0 : (size_t) strtoul(config_count_str, NULL, 10);
+
+		char* config_keys[config_key_count + 1]; // +1 to avoid zero-length VLA.
+		char* config_vals[config_key_count + 1];
+
+		for (size_t k = 0; k < config_key_count; k++) {
+			char* const key = strsep(&tuple, ":");
+			char* const val = strsep(&tuple, ":");
+
+			if (key == NULL || val == NULL) {
+				LOG_FATAL("Could not read dependency tuple (config entry %zu).", k);
+				return -1;
+			}
+
+			config_keys[k] = key;
+			config_vals[k] = val;
+		}
+
 		// Actually create the node object.
 
 		cur->children = realloc(cur->children, (cur->child_count + 1) * sizeof *cur->children);
@@ -192,6 +239,25 @@ int dep_node_deserialize(dep_node_t* root, char* serialized) {
 
 		node->build_path = strdup(build_path);
 		assert(node->build_path != NULL);
+
+		node->config_key_count = config_key_count;
+
+		if (config_key_count == 0) {
+			node->config_keys = NULL;
+			node->config_vals = NULL;
+		} else {
+			node->config_keys = malloc(config_key_count * sizeof *node->config_keys);
+			node->config_vals = malloc(config_key_count * sizeof *node->config_vals);
+
+			assert(node->config_keys != NULL && node->config_vals != NULL);
+
+			for (size_t k = 0; k < config_key_count; k++) {
+				node->config_keys[k] = strdup(config_keys[k]);
+				node->config_vals[k] = strdup(config_vals[k]);
+
+				assert(node->config_keys[k] != NULL && node->config_vals[k] != NULL);
+			}
+		}
 
 		node->child_count = 0;
 		node->children = NULL;

--- a/src/dep_tree.c
+++ b/src/dep_tree.c
@@ -339,6 +339,16 @@ downloaded:
 			flamingo_val_t* const key = config->map.keys[j];
 			flamingo_val_t* const val = config->map.vals[j];
 
+			if (memchr(key->str.str, ':', key->str.size) != NULL || memchr(key->str.str, '\n', key->str.size) != NULL) {
+				LOG_FATAL("Config key '%.*s' must not contain ':' or newline.", (int) key->str.size, key->str.str);
+				return -1;
+			}
+
+			if (memchr(val->str.str, ':', val->str.size) != NULL || memchr(val->str.str, '\n', val->str.size) != NULL) {
+				LOG_FATAL("Config value '%.*s' must not contain ':' or newline.", (int) val->str.size, val->str.str);
+				return -1;
+			}
+
 			deps[i].config_keys[j] = strndup(key->str.str, key->str.size);
 			deps[i].config_vals[j] = strndup(val->str.str, val->str.size);
 

--- a/src/dep_tree.c
+++ b/src/dep_tree.c
@@ -64,7 +64,7 @@ static int gen_local_path(char* path, char** abs_path, char** human, char** dep_
 	*human = strdup(*human);
 	assert(*human != NULL);
 
-	uint64_t const hash = str_hash(*abs_path, strlen(*abs_path));
+	uint64_t const hash = strnhash(*abs_path, strlen(*abs_path));
 
 	asprintf(dep_path, "%s/%s.%" PRIx64 ".local", deps_path, *human, hash);
 	assert(*dep_path != NULL);
@@ -217,8 +217,8 @@ static int ensure_deps_cache(flamingo_val_t* deps_vec, dep_t* deps, uint64_t* ha
 			assert(human != NULL);
 
 			uint64_t const hash =
-				str_hash(git_url->str.str, git_url->str.size) ^
-				str_hash(git_branch->str.str, git_branch->str.size);
+				strnhash(git_url->str.str, git_url->str.size) ^
+				strnhash(git_branch->str.str, git_branch->str.size);
 
 			asprintf(&dep_path, "%s/%s.%" PRIx64 ".git", deps_path, human, hash);
 			assert(dep_path != NULL);
@@ -269,8 +269,8 @@ downloaded:
 
 		deps[i].kind = dep_kind;
 
-		deps[i].hash = str_hash(dep_path, strlen(dep_path)) ^
-			str_hash(build_path->str.str, build_path->str.size);
+		deps[i].hash = strnhash(dep_path, strlen(dep_path)) ^
+			strnhash(build_path->str.str, build_path->str.size);
 		*hash ^= deps[i].hash;
 
 		deps[i].path = strdup(dep_path);
@@ -345,7 +345,7 @@ dep_node_t* get_deps_tree(flamingo_val_t* deps_vec, size_t path_len, uint64_t* p
 		return NULL;
 	}
 
-	uint64_t const would_be_hash = str_hash(tree->path, strlen(tree->path));
+	uint64_t const would_be_hash = strnhash(tree->path, strlen(tree->path));
 
 	// If there are no more dependencies, stop here with just a root node.
 

--- a/src/dep_tree.c
+++ b/src/dep_tree.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2024-2025 Aymeric Wibo
+// Copyright (c) 2024-2026 Aymeric Wibo
 
 #include <common.h>
 
@@ -36,6 +36,10 @@ typedef struct {
 	char* path;
 	char* human;
 	char* build_path;
+
+	size_t config_key_count;
+	char** config_keys;
+	char** config_vals;
 } dep_t;
 
 static int gen_local_path(char* path, char** abs_path, char** human, char** dep_path) {
@@ -73,6 +77,34 @@ static int gen_local_path(char* path, char** abs_path, char** human, char** dep_
 }
 
 /**
+ * Simply hash config map.
+ *
+ * XOR is commutative, which is good because it means when we do 'hash ^=' we don't care about the order of K-V pairs.
+ * However, it's not great that we also XOR the key and val, because it means we would get the same hash if we reversed the key and value.
+ * I think this is fine in practice, but I'll leave a big fat XXX here just in case.
+ *
+ * @param config The config map to hash.
+ * @return The hash.
+ */
+static uint64_t config_hash(flamingo_val_t* config) {
+	assert(config->kind == FLAMINGO_VAL_KIND_MAP);
+	uint64_t hash = 0;
+
+	for (size_t i = 0; i < config->map.count; i++) {
+		flamingo_val_t* const key = config->map.keys[i];
+		flamingo_val_t* const val = config->map.vals[i];
+
+		assert(key->kind == FLAMINGO_VAL_KIND_STR);
+		assert(val->kind == FLAMINGO_VAL_KIND_STR);
+
+		hash ^= strnhash(key->str.str, key->str.size) ^
+			strnhash(val->str.str, val->str.size);
+	}
+
+	return hash;
+}
+
+/**
  * Ensure all dependencies are in Bob's dependency cache.
  *
  * Concretely, do the following:
@@ -104,6 +136,7 @@ static int ensure_deps_cache(flamingo_val_t* deps_vec, dep_t* deps, uint64_t* ha
 		flamingo_val_t* git_branch = NULL;
 
 		flamingo_val_t* build_path = NULL;
+		flamingo_val_t* config = NULL;
 
 		for (size_t j = 0; j < val->inst.scope->vars_size; j++) {
 			flamingo_var_t* const inner = &val->inst.scope->vars[j];
@@ -127,9 +160,14 @@ static int ensure_deps_cache(flamingo_val_t* deps_vec, dep_t* deps, uint64_t* ha
 			else if (flamingo_cstrcmp(inner->key, "build_path", inner->key_size) == 0) {
 				build_path = inner->val;
 			}
+
+			else if (flamingo_cstrcmp(inner->key, "config", inner->key_size) == 0) {
+				config = inner->val;
+			}
 		}
 
 		assert(build_path != NULL); // Can only happen if someone touched bob.fl...
+		assert(config != NULL);     // Can only happen if someone touched bob.fl...
 
 		// Make sure everything checks out and take action.
 
@@ -270,7 +308,8 @@ downloaded:
 		deps[i].kind = dep_kind;
 
 		deps[i].hash = strnhash(dep_path, strlen(dep_path)) ^
-			strnhash(build_path->str.str, build_path->str.size);
+			strnhash(build_path->str.str, build_path->str.size) ^
+			config_hash(config);
 		*hash ^= deps[i].hash;
 
 		deps[i].path = strdup(dep_path);
@@ -281,6 +320,30 @@ downloaded:
 
 		deps[i].build_path = strndup(build_path->str.str, build_path->str.size);
 		assert(deps[i].build_path != NULL);
+
+		// Don't bother checking for any of the Flamingo kinds here; they should've been checked by 'config_hash()' already.
+
+		deps[i].config_key_count = config->map.count;
+
+		if (config->map.count == 0) {
+			// We don't have to set arrays to NULL, because deps is already zeroed.
+			continue;
+		}
+
+		deps[i].config_keys = malloc(config->map.count * sizeof *deps[i].config_keys);
+		deps[i].config_vals = malloc(config->map.count * sizeof *deps[i].config_vals);
+
+		assert(deps[i].config_keys != NULL && deps[i].config_vals != NULL);
+
+		for (size_t j = 0; j < config->map.count; j++) {
+			flamingo_val_t* const key = config->map.keys[j];
+			flamingo_val_t* const val = config->map.vals[j];
+
+			deps[i].config_keys[j] = strndup(key->str.str, key->str.size);
+			deps[i].config_vals[j] = strndup(val->str.str, val->str.size);
+
+			assert(deps[i].config_keys[j] != NULL && deps[i].config_vals[j] != NULL);
+		}
 	}
 
 	return 0;
@@ -294,6 +357,15 @@ void deps_node_free(dep_node_t* node) {
 	free(node->children);
 	free(node->path);
 	free(node->human);
+	free(node->build_path);
+
+	for (size_t i = 0; i < node->config_key_count; i++) {
+		free(node->config_keys[i]);
+		free(node->config_vals[i]);
+	}
+
+	free(node->config_keys);
+	free(node->config_vals);
 }
 
 void deps_tree_free(dep_node_t* tree) {
@@ -309,6 +381,15 @@ void deps_list_free(dep_t* deps, size_t count) {
 	for (size_t i = 0; i < count; i++) {
 		free(deps[i].path);
 		free(deps[i].human);
+		free(deps[i].build_path);
+
+		for (size_t j = 0; j < deps[i].config_key_count; j++) {
+			free(deps[i].config_keys[j]);
+			free(deps[i].config_vals[j]);
+		}
+
+		free(deps[i].config_keys);
+		free(deps[i].config_vals);
 	}
 }
 
@@ -521,6 +602,25 @@ build_tree:;
 
 		node.build_path = strdup(dep->build_path);
 		assert(node.build_path != NULL);
+
+		node.config_key_count = dep->config_key_count;
+
+		if (dep->config_key_count == 0) {
+			node.config_keys = NULL;
+			node.config_vals = NULL;
+		} else {
+			node.config_keys = malloc(dep->config_key_count * sizeof *node.config_keys);
+			node.config_vals = malloc(dep->config_key_count * sizeof *node.config_vals);
+
+			assert(node.config_keys != NULL && node.config_vals != NULL);
+
+			for (size_t j = 0; j < dep->config_key_count; j++) {
+				node.config_keys[j] = strdup(dep->config_keys[j]);
+				node.config_vals[j] = strdup(dep->config_vals[j]);
+
+				assert(node.config_keys[j] != NULL && node.config_vals[j] != NULL);
+			}
+		}
 
 		tree->children = realloc(tree->children, (tree->child_count + 1) * sizeof *tree->children);
 		assert(tree->children != NULL);

--- a/src/deps.c
+++ b/src/deps.c
@@ -42,7 +42,7 @@ static bool build_task(void* data) {
 	// Since we're just building at the moment (no installing), only pass -t, not -p.
 
 	cmd_t CMD_CLEANUP cmd = {0};
-	cmd_create(&cmd, init_name, "-D", "-p", install_prefix, "-C", NULL);
+	cmd_create(&cmd, init_name, "-N", "-p", install_prefix, "-C", NULL);
 	cmd_addf(&cmd, "%s/%s", dep->path, dep->build_path);
 
 	bool dep_own_prefix;

--- a/src/deps.c
+++ b/src/deps.c
@@ -45,6 +45,11 @@ static bool build_task(void* data) {
 	cmd_create(&cmd, init_name, "-N", "-p", install_prefix, "-C", NULL);
 	cmd_addf(&cmd, "%s/%s", dep->path, dep->build_path);
 
+	for (size_t i = 0; i < dep->config_key_count; i++) {
+		cmd_add(&cmd, "-D");
+		cmd_addf(&cmd, "%s=%s", dep->config_keys[i], dep->config_vals[i]);
+	}
+
 	bool dep_own_prefix;
 	assert(would_set_owner(install_prefix, &dep_own_prefix) == 0);
 

--- a/src/deps.h
+++ b/src/deps.h
@@ -1,6 +1,27 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2024-2025 Aymeric Wibo
 
+/*
+ * Behold: The Dependency Tree
+ *
+ *         &&
+ *       &&&&&
+ *     &&&\/& &&&
+ *    &&|,/  |/& &&
+ *     &&/   /  /_&  &&
+ *       \  {  |_____/_&
+ *       {  / /          &&&
+ *       `, \{___________/_&&
+ *        } }{       \
+ *        }{{         \____&
+ *       {}{           `&\&&
+ *       {{}             &&
+ * , -=-~{ .-^- _   ejm
+ *       `}
+ *        {
+ *
+ */
+
 #pragma once
 
 #include <flamingo/flamingo.h>

--- a/src/deps.h
+++ b/src/deps.h
@@ -78,6 +78,13 @@ struct dep_node_t {
 	size_t child_count;
 
 	/**
+	 * Config map passed to this dependency.
+	 */
+	size_t config_key_count;
+	char** config_keys;
+	char** config_vals;
+
+	/**
 	 * If all the dependencies of this node have already been built, this is set.
 	 *
 	 * This field is only used during the dependency build process.

--- a/src/main.c
+++ b/src/main.c
@@ -46,6 +46,10 @@ char* default_tmp_install_prefix = NULL;
 
 bool force_dep_tree_rebuild = false;
 
+size_t dep_config_count = 0;
+char** dep_config_keys = NULL;
+char** dep_config_vals = NULL;
+
 bool running_as_root = false;
 uid_t owner = 0;
 
@@ -66,11 +70,11 @@ void usage(void) {
 	fprintf(
 		stderr,
 		// clang-format off
-		"usage: %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] build\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] run [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] sh [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] install\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] clean\n",
+		"usage: %1$s [-j jobs] [-p install_prefix] [-D KEY=VAL] [-N] [-O] [-C project_directory] [-o out_directory] build\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D KEY=VAL] [-N] [-O] [-C project_directory] [-o out_directory] run [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D KEY=VAL] [-N] [-O] [-C project_directory] [-o out_directory] sh [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D KEY=VAL] [-N] [-O] [-C project_directory] [-o out_directory] install\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-D KEY=VAL] [-N] [-O] [-C project_directory] [-o out_directory] clean\n",
 		// clang-format on
 		progname
 	);
@@ -175,11 +179,30 @@ int main(int argc, char* argv[]) {
 
 	int c;
 
-	while ((c = getopt(argc, argv, "C:fj:NOo:p:")) != -1) {
+	while ((c = getopt(argc, argv, "C:D:fj:NOo:p:")) != -1) {
 		switch (c) {
 		case 'C':
 			project_path = optarg;
 			break;
+		case 'D': {
+			char* const eq = strchr(optarg, '=');
+
+			if (eq == NULL) {
+				LOG_FATAL("'-D' argument must be in KEY=VAL format (got '%s').", optarg);
+				usage();
+			}
+
+			dep_config_keys = realloc(dep_config_keys, (dep_config_count + 1) * sizeof *dep_config_keys);
+			dep_config_vals = realloc(dep_config_vals, (dep_config_count + 1) * sizeof *dep_config_vals);
+			assert(dep_config_keys != NULL && dep_config_vals != NULL);
+
+			dep_config_keys[dep_config_count] = strndup(optarg, (size_t) (eq - optarg));
+			dep_config_vals[dep_config_count] = strdup(eq + 1);
+			assert(dep_config_keys[dep_config_count] != NULL && dep_config_vals[dep_config_count] != NULL);
+
+			dep_config_count++;
+			break;
+		}
 		case 'N':
 			build_deps = false;
 			break;

--- a/src/main.c
+++ b/src/main.c
@@ -426,6 +426,10 @@ int main(int argc, char* argv[]) {
 		assert(bsys_out_path != NULL);
 	}
 
+	if (dep_config_count > 0 && !bsys->supports_config) {
+		LOG_WARN("%s build system does not support config options; -D flags will be ignored.", bsys->name);
+	}
+
 	if (bsys->setup && bsys->setup() < 0) {
 		return EXIT_FAILURE;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -66,11 +66,11 @@ void usage(void) {
 	fprintf(
 		stderr,
 		// clang-format off
-		"usage: %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] build\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] run [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] sh [args ...]\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] install\n"
-		"       %1$s [-j jobs] [-p install_prefix] [-D] [-O] [-C project_directory] [-o out_directory] clean\n",
+		"usage: %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] build\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] run [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] sh [args ...]\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] install\n"
+		"       %1$s [-j jobs] [-p install_prefix] [-N] [-O] [-C project_directory] [-o out_directory] clean\n",
 		// clang-format on
 		progname
 	);
@@ -175,12 +175,12 @@ int main(int argc, char* argv[]) {
 
 	int c;
 
-	while ((c = getopt(argc, argv, "C:Dfj:Oo:p:")) != -1) {
+	while ((c = getopt(argc, argv, "C:fj:NOo:p:")) != -1) {
 		switch (c) {
 		case 'C':
 			project_path = optarg;
 			break;
-		case 'D':
+		case 'N':
 			build_deps = false;
 			break;
 		case 'j':

--- a/src/main.c
+++ b/src/main.c
@@ -192,12 +192,25 @@ int main(int argc, char* argv[]) {
 				usage();
 			}
 
+			size_t const key_len = (size_t) (eq - optarg);
+			char* const val = eq + 1;
+
+			if (memchr(optarg, ':', key_len) != NULL || memchr(optarg, '\n', key_len) != NULL) {
+				LOG_FATAL("Config key '%.*s' must not contain ':' or newline.", (int) key_len, optarg);
+				usage();
+			}
+
+			if (strchr(val, ':') != NULL || strchr(val, '\n') != NULL) {
+				LOG_FATAL("Config value '%s' must not contain ':' or newline.", val);
+				usage();
+			}
+
 			dep_config_keys = realloc(dep_config_keys, (dep_config_count + 1) * sizeof *dep_config_keys);
 			dep_config_vals = realloc(dep_config_vals, (dep_config_count + 1) * sizeof *dep_config_vals);
 			assert(dep_config_keys != NULL && dep_config_vals != NULL);
 
-			dep_config_keys[dep_config_count] = strndup(optarg, (size_t) (eq - optarg));
-			dep_config_vals[dep_config_count] = strdup(eq + 1);
+			dep_config_keys[dep_config_count] = strndup(optarg, key_len);
+			dep_config_vals[dep_config_count] = strdup(val);
 			assert(dep_config_keys[dep_config_count] != NULL && dep_config_vals[dep_config_count] != NULL);
 
 			dep_config_count++;

--- a/src/str.c
+++ b/src/str.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <str.h>
 
-uint64_t str_hash(char const* str, size_t len) { // djb2 algorithm.
+uint64_t strnhash(char const* str, size_t len) { // djb2 algorithm.
 	uint64_t hash = 5381;
 
 	for (size_t i = 0; i < len; i++) {

--- a/src/str.h
+++ b/src/str.h
@@ -7,13 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-// TODO Rename to strnhash.
-
-uint64_t str_hash(char const* str, size_t len);
+uint64_t strnhash(char const* str, size_t len);
 void str_free(char* const* str_ref);
 
 static inline uint64_t strhash(char const* str) {
-	return str_hash(str, strlen(str));
+	return strnhash(str, strlen(str));
 }
 
 #define STR_CLEANUP __attribute__((cleanup(str_free)))

--- a/tests/dep_tree.sh
+++ b/tests/dep_tree.sh
@@ -75,6 +75,19 @@ if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	exit 1
 fi
 
+# Test that config entries are serialized into the dependency tree.
+
+cp tests/deps/build.config.fl tests/deps/build.fl
+rm -rf tests/deps/.bob
+try "Failed to create dependency tree with config"
+
+printf "1:dep2:$DEP2::1:MOMS:spaghetti\n" > $DEPS_TREE_PATH.expected
+
+if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
+	echo "Dependency tree differed to the one expected with config." >&2
+	exit 1
+fi
+
 # Test that circular dependencies fail as they should.
 
 cp tests/deps/build.circular.fl tests/deps/build.fl

--- a/tests/dep_tree.sh
+++ b/tests/dep_tree.sh
@@ -31,9 +31,9 @@ fi
 DEP1=$(find $BOB_DEPS_PATH -name "*dep1*")
 DEP2=$(find $BOB_DEPS_PATH -name "*dep2*")
 
-printf "1:dep1:$DEP1:\n" > $DEPS_TREE_PATH.expected
-printf "\t1:dep2:$DEP2:\n" >> $DEPS_TREE_PATH.expected
-printf "1:dep2:$DEP2:\n" >> $DEPS_TREE_PATH.expected
+printf "1:dep1:$DEP1::0\n" > $DEPS_TREE_PATH.expected
+printf "\t1:dep2:$DEP2::0\n" >> $DEPS_TREE_PATH.expected
+printf "1:dep2:$DEP2::0\n" >> $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected." >&2
@@ -55,8 +55,8 @@ fi
 cp tests/deps/build.changed.fl tests/deps/build.fl
 try "Failed to create dependency tree after changing dependencies"
 
-printf "1:dep1:$DEP1:\n" > $DEPS_TREE_PATH.expected
-printf "\t1:dep2:$DEP2:\n" >> $DEPS_TREE_PATH.expected
+printf "1:dep1:$DEP1::0\n" > $DEPS_TREE_PATH.expected
+printf "\t1:dep2:$DEP2::0\n" >> $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected after changing dependencies." >&2
@@ -68,7 +68,7 @@ fi
 cp tests/deps/build.duplicate.fl tests/deps/build.fl
 try "Failed to create dependency tree with duplicates in the dependency vector"
 
-printf "1:dep2:$DEP2:\n" > $DEPS_TREE_PATH.expected
+printf "1:dep2:$DEP2::0\n" > $DEPS_TREE_PATH.expected
 
 if ! diff $DEPS_TREE_PATH $DEPS_TREE_PATH.expected; then
 	echo "Dependency tree differed to the one expected with duplicates in the dependency vector." >&2

--- a/tests/deps/build.config.fl
+++ b/tests/deps/build.config.fl
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 Aymeric Wibo
+
+import bob
+
+deps = [
+	Dep.local("dep2")
+		.conf("MOMS", "spaghetti"),
+]


### PR DESCRIPTION
Resolves #138 

TODO:

- [x] Be able to parse `Dep.config` map, and add this to `deps.tree` file.
- [x] Use in CMake BSYS.
- [x] Warning that config is not supported by BSYS yet if config map has len > 0.
- [x] Tests.
- [x] Check that delimiter or newline not in config key or val.