### PR TITLE
 deps: Don't rebuild git deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Async command execution via a worker pool.
 
 ### Global state (`src/common.h`)
 
-Key globals: `instr` (current instruction), `abs_out_path` (.bob/$TARGET/), `install_prefix`, `deps_path`, `debugging`.
+Key globals: `instr` (current instruction), `target` (e.g. `amd64-FreeBSD`, from `BOB_TARGET` or `uname`), `abs_out_path` (`.bob/$TARGET/`), `install_prefix`, `deps_path`, `debugging`.
 
 `BOB_BUILD_DEBUGGING=1` sets `debugging=true`: forces `-j1` (no parallelism) and disables output pipe buffering so command output streams in real-time. Use when diagnosing hangs or other unobvious build failures.
 

--- a/src/bsys/gmake/main.c
+++ b/src/bsys/gmake/main.c
@@ -64,8 +64,6 @@ static int install(void) {
 	cmd_add(&cmd, "install");
 	cmd_set_redirect(&cmd, CMD_NO_REDIRECT, CMD_NO_FORCE_REDIRECT);
 
-	cmd_print(&cmd);
-
 	if (cmd_exec(&cmd) < 0) {
 		LOG_FATAL("GNU Make install failed.");
 		return -1;

--- a/src/common.h
+++ b/src/common.h
@@ -63,6 +63,13 @@ extern char const* bootstrap_import_path;
 extern char const* targetless_out_path;
 
 /**
+ * The build target triple (e.g. "amd64-FreeBSD").
+ *
+ * Set from the BOB_TARGET envvar if present, otherwise derived from uname(3) as "$machine-$sysname".
+ */
+extern char* target;
+
+/**
  * The absolute ".bob/$TARGET/" output path.
  */
 extern char const* abs_out_path;

--- a/src/deps.c
+++ b/src/deps.c
@@ -3,22 +3,23 @@
 
 #include <common.h>
 
+#include <alloc.h>
 #include <cmd.h>
 #include <deps.h>
 #include <fsutil.h>
 #include <logging.h>
 #include <ncpu.h>
 #include <pool.h>
+#include <str.h>
 
 #include <assert.h>
 #include <sys/param.h>
+#include <unistd.h>
 
 static pthread_mutex_t logging_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static bool build_task(void* data) {
 	dep_node_t* const dep = data;
-
-	// TODO If dep->kind == DEP_KIND_GIT, we should not be rebuilding this at all so long as a relative $out_path (I think?) directory exists (though what happens if we need to reinstall?).
 
 	// Log that we're building.
 
@@ -29,6 +30,26 @@ static bool build_task(void* data) {
 
 		if (human++ == NULL) {
 			human = dep->path;
+		}
+	}
+
+	// For git dependencies, check if we've already built this dependency by seeing if the output directory exists.
+	// Git dependencies are immutable (modulo updates, which aren't yet implemented) and separated by tag/branch, so no need to rebuild.
+
+	if (dep->kind == DEP_KIND_GIT) {
+		char* STR_CLEANUP check_path = NULL;
+
+		if (dep->build_path[0] != '\0') {
+			asprintf_c(&check_path, "%s/%s/.bob/%s", dep->path, dep->build_path, target);
+		} else {
+			asprintf_c(&check_path, "%s/.bob/%s", dep->path, target);
+		}
+
+		if (access(check_path, F_OK) == 0) {
+			pthread_mutex_lock(&logging_lock);
+			LOG_INFO("%s" CLEAR ": Git dependency already built, skipping.", human);
+			pthread_mutex_unlock(&logging_lock);
+			return false;
 		}
 	}
 

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,7 @@ char const* init_name = "bob";
 char const* bootstrap_import_path = "import";
 
 char const* targetless_out_path = NULL;
+char* target = NULL;
 char const* abs_out_path = NULL;
 char* bsys_out_path = NULL;
 
@@ -340,7 +341,7 @@ int main(int argc, char* argv[]) {
 
 	// Get target and append to out path.
 
-	char* target = getenv("BOB_TARGET");
+	target = getenv("BOB_TARGET");
 
 	if (target == NULL) {
 		struct utsname u;


### PR DESCRIPTION
Resolves #78 

Still need to test this out (worth write tests for?).

ACTUALLY this isn't going to work because I still need to install the dependency. Maybe have a switch to decide if we rebuild or just install? Also we could just install if we had to clear the prefix. AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA